### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 ## General
 
-- [Public Invidious Instances](./Invidious-Instances)
-- [Extensions](./Extensions)
-- [Always proxy videos through server](./Always-use-"local"-to-proxy-video-through-the-server-without-creating-an-account)
-- [Preferences](./Preferences)
-- [Geoblocking, available quality and DASH](./Geoblocking,-available-video-quality-and-DASH)
-- [Using search operators](./Search-operators)
-- [List of URL parameters](./List-of-URL-parameters)
-- [How to deal with uMatrix](./How-to-deal-with-uMatrix)
+- [Public Invidious Instances](./Invidious-Instances.md)
+- [Extensions](./Extensions.md)
+- [Always proxy videos through server](./Always-use-"local"-to-proxy-video-through-the-server-without-creating-an-account.md)
+- [Preferences](./Preferences.md)
+- [Geoblocking, available quality and DASH](./Geoblocking,-available-video-quality-and-DASH.md)
+- [Using search operators](./Search-operators.md)
+- [List of URL parameters](./List-of-URL-parameters.md)
+- [How to deal with uMatrix](./How-to-deal-with-uMatrix.md)
 
 ## For Administrators
 
-- [Configuration](./Configuration)
-- [Updating](./Updating)
-- [Apache2 Virtual Host with Reverse Proxy](./Apache2-Reverse-Proxy)
-- [Nginx Reverse Proxy Configuration](./NGINX-Reverse-Proxy)
-- [Database Information and Maintenance](./Database-Information-and-Maintenance)
-- [Issues with CAPTCHA](./Issues-with-CAPTCHA-on-Debian-and-Ubuntu)
-- [How to setup Anti-Captcha](./How-to-setup-Anti-Captcha)
+- [Configuration](./Configuration.md)
+- [Updating](./Updating.md)
+- [Apache2 Virtual Host with Reverse Proxy](./Apache2-Reverse-Proxy.md)
+- [Nginx Reverse Proxy Configuration](./NGINX-Reverse-Proxy.md)
+- [Database Information and Maintenance](./Database-Information-and-Maintenance.md)
+- [Issues with CAPTCHA](./Issues-with-CAPTCHA-on-Debian-and-Ubuntu.md)
+- [How to setup Anti-Captcha](./How-to-setup-Anti-Captcha.md)
 
 ## For Developers
 
-- [API](./API)
-- [Authenticated Endpoints](./Authenticated-Endpoints)
+- [API](./API.md)
+- [Authenticated Endpoints](./Authenticated-Endpoints.md)


### PR DESCRIPTION
All of the links in README leads to a 404 page unless you put `.md` at the end of it. Putting `.md` at the end of each link fixes it.

Example:
https://github.com/iv-org/documentation/blob/master/Invidious-Instances is a 404, but https://github.com/iv-org/documentation/blob/master/Invidious-Instances.md is not.