### PR TITLE
Add instructions for exporting YouTube subscriptions

### DIFF
--- a/Export-YouTube-subscriptions.md
+++ b/Export-YouTube-subscriptions.md
@@ -1,0 +1,11 @@
+**The steps below as well as the resulting file name are different depending on your Google language 
+settings.**
+
+1. Open [Google Takeout](https://takeout.google.com/takeout/custom/youtube).
+2. Under `Create a new export` choose `YouTube and YouTube Music`.
+3. Click on `All YouTube data included` and only tick `subscriptions` in the dialog that opens.
+4. Click on `Next step`, make sure `Export once` is chosen and click on `Create export`.
+5. Wait until the export creation is finished, then on the same page click on `Download` under  
+   `Your latest export` that should now be visible.
+6. Extract the downloaded archive and find the file `subscriptions.json`.
+7. Upload this file into Invidious.

--- a/Export-YouTube-subscriptions.md
+++ b/Export-YouTube-subscriptions.md
@@ -8,4 +8,6 @@ settings.**
 5. Wait until the export creation is finished, then on the same page click on `Download` under  
    `Your latest export` that should now be visible.
 6. Extract the downloaded archive and find the file `subscriptions.json`.
-7. Upload this file into Invidious.
+7. While logged into your Invidious account go to Subscriptions -> Manage Subscriptions -> 
+   Import/Export -> Import YouTube subscriptions, select the file you just downloaded and click on 
+   `Import`.


### PR DESCRIPTION
Adds a new article with instructions on how to export your YouTube subscriptions from Google Takeout.