### PR TITLE
Remove Invidious.tube

### DIFF
--- a/Invidious-Instances.md
+++ b/Invidious-Instances.md
@@ -28,9 +28,6 @@ Instances using any type of analytics are marked as such, must be GDPR compliant
 
 * [yewtu.be](https://yewtu.be) 🇳🇱 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d)](https://status.unixfox.eu/783898765)
 
-* [invidious.tube](https://invidious.tube/) 🇳🇱 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m785789197-f3d9d125d986bcc9664df1da?style=social)](https://status.invidious.tube)
-Uses custom anti-bot protection that requires a cookie: https://github.com/kyprizel/testcookie-nginx-module
-
 * [invidious.kavin.rocks](https://invidious.kavin.rocks) 🇮🇳 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71)](https://status.kavin.rocks/786132664) (uses Cloudflare)
 
 * [tube.connect.cafe](https://tube.connect.cafe) 🇫🇷


### PR DESCRIPTION
Invidious.tube logs IP addresses and puts them on the IP address blacklist site abuseipdb.com for no reason along with the path the user using the site requested. This isn't stated on the site's TOS.

Sites TOS:

![](https://cdn.riverside.rocks/a/gasoline-spear-cauliflower.png)

IP addresses being reported:

![](https://cdn.riverside.rocks/a/fold-kumquat-weather.png)

Many of the IPs being reported are random residential IP addresses:

![](https://cdn.riverside.rocks/a/geometry-degree-macaroon.png)
![](https://cdn.riverside.rocks/a/allosaurus-turtle-honesty.png)
![](https://cdn.riverside.rocks/a/menu-triangle-buckthornpepperberry.png)

Archived page:

https://web.archive.org/web/20210308182858/https://www.abuseipdb.com/user/28030

Live page:

https://www.abuseipdb.com/user/28030