### PR TITLE
Alternative take on the instance list rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Create markdown list
 
 on: 
+  workflow_dispatch:
   push:
     branches: "*"
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Create markdown list
+
+on: 
+  pull_request:
+    branches: "*"
+    paths:
+     - 'instances.yaml'
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.5
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r src/requirements.txt
+      
+      - name: Create markdown instance list
+        run: |
+          python src/create-instance-md.py
+    
+      # Auto commit resulting md file
+      - name: "Auto commiting resulting markdown instance list"
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update Invidious-Instances.md          
+          file_pattern: Invidious-Instances.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Create markdown list
 
 on: 
+  push:
+    branches: "*"
+    paths:
+     - 'instances.yaml'
+
   pull_request:
     branches: "*"
     paths:

--- a/Invidious-Instances.md
+++ b/Invidious-Instances.md
@@ -1,82 +1,70 @@
----
-title: Invidious-Instances
-description: 
-published: true
-date: 2021-05-23T16:58:51.441Z
-tags: 
-editor: markdown
-dateCreated: 2021-05-23T16:58:48.431Z
----
-
-# Public Invidious Instances:
-
-[Uptime History provided by Uptimerobot](https://stats.uptimerobot.com/89VnzSKAn)
-
-[Instances API](https://instances.invidio.us/)
 
 
-**Note:**
-
-Instances using Cloudflare are marked as such. Instances using any type of anti-bot protection are marked as such.
-
-Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it.
-
-To be in this list, instances must have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and will be removed from the list.
-
-**Warning: Any public instance that isn't in this list is considered untrustworthy. Use them at your own risk.**
-
-## List of public Invidious Instances (sorted from oldest to newest):
-
-* [invidious.snopyta.org](https://invidious.snopyta.org/) 🇫🇮
-
-* [yewtu.be](https://yewtu.be) 🇳🇱 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d)](https://uptime.invidious.io/784257752)
-
-* [invidious.kavin.rocks](https://invidious.kavin.rocks) 🇮🇳 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71)](https://status.kavin.rocks/786132664) [invidious-us.kavin.rocks](https://invidious-us.kavin.rocks) 🇺🇸 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a)](https://status.kavin.rocks/788216947) [invidious-jp.kavin.rocks](https://invidious-jp.kavin.rocks) 🇯🇵 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m788866642-8a4478b8853722e98b7634e9)](https://status.kavin.rocks/788866642) (uses Cloudflare)
-
-* [vid.puffyan.us](https://vid.puffyan.us) 🇺🇸 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3?style=plastic)](https://stats.uptimerobot.com/n7A08HGVl6/786947233)
-
-* [ytprivate.com](https://ytprivate.com) 🇺🇸 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786947505-2a50cf3262906bb28c6cf8fc)](https://status.ytprivate.com/786947505) (uses DDoS-Guard) (is running a modified source code) - Source Code: https://github.com/ytprivatecom/invidious - Changes: https://github.com/ytprivatecom/invidious#source-changes
-
-* [invidious.namazso.eu](https://invidious.namazso.eu) 🇩🇪
-
-* [invidious.silkky.cloud](https://invidious.silkky.cloud) 🇫🇮 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793)](https://status.silkky.cloud/787784614) - Uses anti-bot protection by bunkerized-nginx: https://github.com/bunkerity/bunkerized-nginx
-
-* [invidious.exonip.de](https://invidious.exonip.de) 🇩🇪 [Status Page](https://status.exonip.de/) - Source code/changes: https://github.com/exonip-de/invidious-source-modifications - Uses anti-bot protection by bunkerized-nginx: https://github.com/bunkerity/bunkerized-nginx
-
-* [inv.riverside.rocks](https://inv.riverside.rocks) 🇺🇸
-
-* [vid.mint.lgbt](https://vid.mint.lgbt) 🇨🇦 [Status Page](https://status.mint.lgbt/service/lesvidious)
-
-* [ytb.trom.tf](https://ytb.trom.tf) 🇩🇪 Source code/changes (just CSS additions): https://gitlab.com/TioTrom/trom.tf-invidious
-
-* [y.com.cm](https://y.com.cm) 🇩🇪 (uses Cloudflare)
-
-* [invidious.hub.ne.kr](https://invidious.hub.ne.kr) 🇰🇷
-
-* [invidio.xamh.de](https://invidio.xamh.de) 🇩🇪 ![Uptime Robot status](https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8)
-
-* [youtube.076.ne.jp](https://youtube.076.ne.jp) 🇯🇵 - Source code/changes: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
-
-* [yt.didw.to](https://yt.didw.to/) 🇸🇪
-
-* [yt.artemislena.eu](https://yt.artemislena.eu) 🇩🇪
 
 
-### Tor Onion Services:
-* [c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion](http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion)
+# Public Instances
 
-* [w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion](http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/)
 
-* [kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion](http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/) 🇳🇱
+Uptime History: [uptime.invidious.io](https://uptime.invidious.io)
 
-* [grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion](http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion) 🇺🇸
+Instances API: [api.invidious.io](api.invidious.io)  
 
-* [hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion](http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion) 🇺🇸 (Onion of invidious-us.kavin.rocks)
+# Instances list
 
-* [invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion](http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion) 🇩🇪 (Onion of invidious.exonip.de)
+|Address|Country|Mirrors|Status|Privacy policy|DDos Protection / MITM|Owner|Notes|
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+|[invidious.snopyta.org](https://invidious.snopyta.org)|Finland 🇫🇮||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d)](https://status.unixfox.eu/783898765)|[Here](https://snopyta.org/privacy_policy)||[@Perflyst](https://github.com/Perflyst)||
+|[yewtu.be](https://yewtu.be)|Niger 🇳🇪||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d)](https://uptime.invidious.io/784257752)|||[@unixfox](https://github.com/unixfox)||
+|[invidious.kavin.rocks](https://invidious.kavin.rocks)|India 🇮🇳|[United States 🇺🇸](https://invidious-us.kavin.rocks)<br/>[Japan 🇯🇵](https://invidious-jp.kavin.rocks)|[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71)](https://status.kavin.rocks/786132664)||Cloudflare|[@FireMasterK](https://github.com/FireMasterK)||
+|[vid.puffyan.us](https://vid.puffyan.us)|United States 🇺🇸||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3)](https://stats.uptimerobot.com/n7A08HGVl6/786947233)|||[@ItsSt0ne](https://github.com/ItsSt0ne)||
+|[ytprivate.com](https://ytprivate.com)|United States 🇺🇸||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m786947505-2a50cf3262906bb28c6cf8fc)](https://status.ytprivate.com/786947505)||DDoS-Guard|[@ytprivatecom](https://github.com/ytprivatecom)| - [Modified source code](https://github.com/ytprivatecom/invidious)<br/> - [Changes](https://github.com/ytprivatecom/invidious#source-changes)|
+|[invidious.namazso.eu](https://invidious.namazso.eu)|Germany 🇩🇪|||[Here](https://namazso.eu/privacy.html)||[@namazso](https://github.com/namazso)||
+|[invidious.silkky.cloud](https://invidious.silkky.cloud)|Finland 🇫🇮||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793)](https://status.silkky.cloud/787784614)|[Here](https://silkky.cloud/privacy)||[@silkkycloud](https://github.com/silkkycloud)| - [Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)|
+|[invidious.exonip.de](https://invidious.exonip.de)|Germany 🇩🇪||[Status Page](https://status.exonip.de/)|||[@Exonip](https://github.com/Exonip)| - [Modified source code](https://github.com/exonip-de/invidious-source-modifications)<br/> - [Changes](https://github.com/exonip-de/invidious-source-modifications)<br/> - [Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)|
+|[inv.riverside.rocks](https://inv.riverside.rocks)|United States 🇺🇸|||||[@RiversideRocks](https://github.com/RiversideRocks)||
+|[vid.mint.lgbt](https://vid.mint.lgbt/)|Canada 🇨🇦||[Status Page](https://status.mint.lgbt/service/lesvidious)|||[@mintphin](https://github.com/mintphin)||
+|[ytb.trom.tf](https://ytb.trom.tf)|Germany 🇩🇪|||||[@TROMsite](https://github.com/TROMsite)| - [Modified source code](https://gitlab.com/TioTrom/trom.tf-invidious)<br/> - [Changes](https://gitlab.com/TioTrom/trom.tf-invidious)|
+|[y.com.cm](https://y.com.cm/)|Germany 🇩🇪||||Cloudflare|[@Showfom](https://github.com/Showfom)||
+|[invidious.hub.ne.kr](https://invidious.hub.ne.kr)|Korea, Republic of 🇰🇷|||[Here](https://privacy.osbusiness.net/)||[@hys0star](https://github.com/hys0star)||
+|[invidio.xamh.de](https://invidio.xamh.de)|Germany 🇩🇪||[![Uptime Robot status](https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8)](https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8)|||[@11Tuvork28](https://github.com/11Tuvork28)||
+|[youtube.076.ne.jp](https://youtube.076.ne.jp)|Japan 🇯🇵|||||[@TechnicalSuwako](https://github.com/TechnicalSuwako)| - [Modified source code](https://git.076.ne.jp/TechnicalSuwako/invidious-mod)<br/> - [Changes](https://git.076.ne.jp/TechnicalSuwako/invidious-mod#change)|
+|[yt.didw.to](https://yt.didw.to/)|Sweden 🇸🇪|||||[@didw-to](https://github.com/didw-to)||
+|[yt.artemislena.eu](https://yt.artemislena.eu)|Germany 🇩🇪|||[Here](https://artemislena.eu/privacy.html)||[@artemislena](https://github.com/artemislena)||
+  
 
-* [osbivz6guyeahrwp2lnwyjk2xos342h4ocsxyqrlaopqjuhwn2djiiyd.onion](http://osbivz6guyeahrwp2lnwyjk2xos342h4ocsxyqrlaopqjuhwn2djiiyd.onion) 🇰🇷 (Onion of invidious.hub.ne.kr)
+# Onion instances list
 
-* [p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion](http://p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion) 🇯🇵 (Onion of invidious-jp.kavin.rocks)
+|Address|Country|Mirrors|Associated clearnet instance|Privacy policy|Owner|Notes|
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+|[c7hqkpkpemu6e7emz5b4vyz7idjgdv...](http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion)|Finland 🇫🇮||[invidious.snopyta.org](https://invidious.snopyta.org)|[Here](https://snopyta.org/privacy_policy)|[@Perflyst](https://github.com/Perflyst)||
+|[w6ijuptxiku4xpnnaetxvnkc5vqcdu...](http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/)|India 🇮🇳|[United States 🇺🇸](http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/)<br/>[Japan 🇯🇵](http://p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion/)|[invidious.kavin.rocks](https://invidious.kavin.rocks)||[@FireMasterK](https://github.com/FireMasterK)||
+|[kbjggqkzv65ivcqj6bumvp337z6264...](http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/)|Netherlands 🇳🇱||||[@tirz](https://github.com/tirz)||
+|[grwp24hodrefzvjjuccrkw3mjq4tzh...](http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/)|United States 🇺🇸||[vid.puffyan.us](https://vid.puffyan.us)||[@ItsSt0ne](https://github.com/ItsSt0ne)||
+|[invidc4i7i5uci6cledxsao6w7ng5e...](http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/)|Germany 🇩🇪||[invidious.exonip.de](https://invidious.exonip.de)||[@Exonip](https://github.com/Exonip)| - [Modified source code](https://github.com/exonip-de/invidious-source-modifications)<br/> - [Changes](https://github.com/exonip-de/invidious-source-modifications)|
+|[pwo2md4lgxs3hvroqi6wg33h6a3pv4...](http://pwo2md4lgxs3hvroqi6wg33h6a3pv47euax6km3alke7letglieokyd.onion)|Korea, Republic of 🇰🇷||[invidious.hub.ne.kr](https://invidious.hub.ne.kr)||[@hys0star](https://github.com/hys0star)||
+|[k7mnd6gyelynroxoncodxjz44fd5ch...](http://k7mnd6gyelynroxoncodxjz44fd5ch2ewfjl2a6ozmg3jy6fwyxq3cyd.onion/)|Sweden 🇸🇪||[yt.didw.to](https://yt.didw.to/)||[@didw-to](https://github.com/didw-to)||
+  
 
-* [k7mnd6gyelynroxoncodxjz44fd5ch2ewfjl2a6ozmg3jy6fwyxq3cyd.onion](http://k7mnd6gyelynroxoncodxjz44fd5ch2ewfjl2a6ozmg3jy6fwyxq3cyd.onion/) 🇸🇪 (Onion of yt.didw.to)
+# Adding your instance
+
+## Prerequisites
+
+- Instances must have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and is removed from the list.
+- Instances must have statistics (/api/v1/stats) enabled (statistics_enabled:true in the configuration file)
+- Instances must be served via domain name.
+- Instances must be served via HTTPS.
+- Instances using any DDoS Protection / MITM are marked as such.
+- Instances using any type of anti-bot protection are marked as such.
+- Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it.
+- Instances running a modified source code must respect the AGPL by publishing their source code and stating their changes before they are be added to the list, and must publish any later modification in a timely manner.
+    - The instance must also contain a link to *both* the modified and original source code of Invidious. Ideally in the footer.
+- Instances should be up and functional at least 90% of the time.
+  
+  
+
+## Directions
+
+1. Fork the documentation repo.
+2. Open `instances.yaml` for editing.
+3. Append your instance to the bottom of the HTTPS (or onion) list. See the examples in the yaml file for more info.
+4. Make a pull request.

--- a/instances.yaml
+++ b/instances.yaml
@@ -8,6 +8,7 @@ adding_instance:
     - Instances using any type of anti-bot protection are marked as such.
     - "Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it."
     - Instances running a modified source code must respect the AGPL by publishing their source code and stating their changes before they are be added to the list, and must publish any later modification in a timely manner.
+    - Instances should be up and functional at least 90% of the time.
   directions:
     - Fork the documentation repo.
     - Open `instances.yaml` for editing.

--- a/instances.yaml
+++ b/instances.yaml
@@ -41,8 +41,8 @@ instances:
       privacy_policy: https://snopyta.org/privacy_policy
       ddos_mitm_protection: null
       owner: https://github.com/Perflyst
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://yewtu.be
@@ -51,8 +51,8 @@ instances:
       privacy_policy: null
       ddos_mitm_protection: null
       owner: https://github.com/unixfox
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious.kavin.rocks
@@ -65,8 +65,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious-us.kavin.rocks
@@ -79,8 +79,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://vid.puffyan.us
@@ -93,8 +93,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/ItsSt0ne
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious.namazso.eu
@@ -103,8 +103,8 @@ instances:
       privacy_policy: https://namazso.eu/privacy.html
       ddos_mitm_protection:
       owner: https://github.com/namazso
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious.silkky.cloud
@@ -117,8 +117,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TheSilkky
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes: 
         - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
 
@@ -127,7 +127,7 @@ instances:
       status: 
         url: https://status.exonip.de/
         display_content: Status Page
-        display_content_is_image: False
+        display_content_is_image:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Exonip
@@ -142,8 +142,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/RiversideRocks
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious.blamefran.net
@@ -152,8 +152,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Aidan16
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://invidious.moomoo.me
@@ -162,8 +162,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/moom0o
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://ytb.trom.tf
@@ -172,8 +172,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TROMsite
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://yt.cyberhost.uk/
@@ -187,8 +187,8 @@ instances:
       ddos_mitm_protection:
       owner: https://github.com/cyberhost-uk
       modified:
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: https://y.com.cm/
@@ -197,8 +197,18 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/Showfom
-      is_modified: false
-      source: null
+      is_modified:
+      source:
+      notes:
+
+    - url: https://invidious.s1gm4.eu
+      country: FR
+      status: 
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/OrnithOrtion
+      is_modified:
+      source:
       notes:
   
     - url: https://invidious.hub.ne.kr
@@ -207,8 +217,8 @@ instances:
       privacy_policy:
       ddos_mitm_protection: null
       owner: https://github.com/hys0star
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
 
@@ -228,8 +238,8 @@ instances:
       associated_clearnet_instance: https://invidious.snopyta.org
       privacy_policy:
       owner: https://github.com/Perflyst
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/
@@ -237,8 +247,8 @@ instances:
       associated_clearnet_instance: https://invidious.kavin.rocks
       privacy_policy:
       owner: https://github.com/FireMasterK
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/
@@ -246,8 +256,8 @@ instances:
       associated_clearnet_instance:
       privacy_policy:
       owner: https://github.com/tirz
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/
@@ -255,8 +265,8 @@ instances:
       associated_clearnet_instance: https://vid.puffyan.us
       privacy_policy:
       owner: https://github.com/ItsSt0ne
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
@@ -264,8 +274,8 @@ instances:
       associated_clearnet_instance: https://invidious-us.kavin.rocks/
       privacy_policy:
       owner: https://github.com/FireMasterK
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://xinzguzyta7riddeoygku6btmm3mdryxtfzwwjxy3zqpoxk3xg5qq6ad.onion
@@ -273,8 +283,8 @@ instances:
       associated_clearnet_instance: https://invidious.moomoo.me
       privacy_policy:
       owner: https://github.com/moom0o
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 
     - url: http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/
@@ -291,7 +301,7 @@ instances:
       associated_clearnet_instance: https://invidious.hub.ne.kr
       privacy_policy:
       owner: https://github.com/hys0star
-      is_modified: false
-      source: null
+      is_modified:
+      source:
       notes:
 

--- a/instances.yaml
+++ b/instances.yaml
@@ -340,3 +340,12 @@ instances:
       source:
       notes:
 
+    - url: http://p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion/
+      country: JP
+      associated_clearnet_instance: https://invidious-jp.kavin.rocks
+      privacy_policy:
+      owner: https://github.com/FireMasterK
+      is_modified:
+      source:
+      notes:
+

--- a/instances.yaml
+++ b/instances.yaml
@@ -1,0 +1,286 @@
+adding_instance:
+  prerequisites:
+    - Instances must have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and is removed from the list.
+    - Instances must have statistics (/api/v1/stats) enabled (statistics_enabled:true in the configuration file)
+    - Instances must be served via domain name.
+    - Instances must be served via domain name.
+    - Instances using any DDoS Protection / MITM are marked as such.
+    - Instances using any type of anti-bot protection are marked as such.
+    - "Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it."
+    - Instances running a modified source code must respect the AGPL by publishing their source code and stating their changes before they are be added to the list, and must publish any later modification in a timely manner.
+  directions:
+    - Fork the documentation repo.
+    - Open `instances.yaml` for editing."
+    - Append your instance to the bottom of the HTTPS (or onion) list. See the examples in the yaml file for more info.
+    - Make a pull request.
+
+instances:
+  https:
+    # Template instance
+    # - url: example.com
+    #   country:
+    #     flag: 🇫🇮
+    #     name: Finland
+    #   status_url: status.example.com
+    #   privacy_policy: privacy.example.com
+    #   ddos_mitm_protection: Cloudflare
+    #   owner: https://github.com/example
+    #   modified:
+    #     is_modified: False
+    #     source_url: null
+
+
+    - url: https://invidious.snopyta.org
+      country:
+        flag: 🇫🇮
+        name: Finland
+      status: 
+        url: https://status.unixfox.eu/783898765
+        display_content: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy: https://snopyta.org/privacy_policy
+      ddos_mitm_protection: null
+      owner: https://github.com/Perflyst
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://yewtu.be
+      country:
+        flag: 🇫🇷
+        name: France
+      status: null
+      privacy_policy: null
+      ddos_mitm_protection: null
+      owner: https://github.com/unixfox
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious.kavin.rocks
+      country:
+        flag: 🇮🇳
+        name: India
+      status:
+        url: https://status.kavin.rocks/786132664
+        display_content: https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: Cloudflare
+      owner: https://github.com/FireMasterK
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious-us.kavin.rocks
+      country:
+        flag: 🇺🇸
+        name: USA
+      status: 
+        url: https://status.kavin.rocks/788216947
+        display_content: https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: Cloudflare
+      owner: https://github.com/FireMasterK
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious.048596.xyz
+      country:
+        flag: 🇨🇦
+        name: Canada
+      status: 
+        url: https://status.048596.xyz/786792286
+        display_content: https://img.shields.io/uptimerobot/status/m786792286-b5894e4e11c42b8332375076
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/tenpura-shrimp
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://vid.puffyan.us
+      country:
+        flag: 🇺🇸
+        name: USA
+      status: 
+        url: https://stats.uptimerobot.com/n7A08HGVl6/786947233
+        display_content: https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/ItsSt0ne
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://ytprivate.com
+      country:
+        flag: 🇺🇸
+        name: USA
+      status: 
+        url: https://status.ytprivate.com/786947505
+        display_content:  https://img.shields.io/uptimerobot/status/m786947505-2a50cf3262906bb28c6cf8fc
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: DDoS-Guard
+      owner: https://github.com/ytprivatecom
+      modified:
+        is_modified: True
+        source_url: https://github.com/ytprivatecom/invidious
+
+    - url: https://invidious.namazso.eu
+      country:
+        flag: 🇩🇪
+        name: Germany
+      status: 
+      privacy_policy: https://namazso.eu/privacy.html
+      ddos_mitm_protection:
+      owner: https://github.com/namazso
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious.silkky.cloud
+      country:
+        flag: 🇫🇮
+        name: Finland
+      status: 
+        url: https://status.silkky.cloud/787784614
+        display_content:  https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/TheSilkky
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious.exonip.de
+      country:
+        flag: 🇩🇪
+        name: Germany
+      status: 
+        url: https://status.exonip.de/
+        display_content:  Uptime Robot status
+        display_content_is_image: False
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/Exonip
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://notyoutube.org
+      country:
+        flag: 🇫🇮
+        name: Finland
+      status:
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/Eggo-Plant
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://inv.riverside.rocks
+      country:
+        flag: 🇺🇸
+        name: USA
+      status:
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/RiversideRocks
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: https://invidious.blamefran.net
+      country:
+        flag: 🇺🇸
+        name: USA
+      status:
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/Aidan16
+      modified:
+        is_modified: False
+        source_url: null
+
+  onion:
+    # Template onion instance
+    # - url: http://example.onion
+    #   country:
+    #     flag: 🇺🇸
+    #     name: USA
+    #   associated_clearnet_instance: example.com
+    #   privacy_policy: privacy.example.com
+    #   owner: https://github.com/example
+    #   modified:
+    #     is_modified: False
+    #     source_url: null
+
+    - url: http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion
+      country:
+        flag: 🇫🇮
+        name: Finland
+      invidious.snopyta.org: invidious.snopyta.org
+      privacy_policy:
+      owner: https://github.com/Perflyst
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/
+      country:
+        flag: 🇮🇳
+        name: India
+      associated_clearnet_instance: https://invidious.kavin.rocks
+      privacy_policy:
+      owner: https://github.com/FireMasterK
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/
+      country:
+        flag: 🇳🇱
+        name: Netherlands
+      associated_clearnet_instance:
+      privacy_policy:
+      owner: https://github.com/tirz
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/
+      country:
+        flag: 🇺🇸
+        name: USA
+      associated_clearnet_instance: https://vid.puffyan.us
+      privacy_policy:
+      owner: https://github.com/ItsSt0ne
+      modified:
+        is_modified: False
+        source_url: null
+
+    - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
+      country:
+        flag: 🇺🇸
+        name: USA
+      associated_clearnet_instance: https://invidious-us.kavin.rocks/
+      privacy_policy:
+      owner: https://github.com/FireMasterK
+      modified:
+        is_modified: False
+        source_url: null

--- a/instances.yaml
+++ b/instances.yaml
@@ -132,9 +132,9 @@ instances:
         url: https://status.silkky.cloud/787784614
         image:  https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793
         text: Uptime Robot status
-      privacy_policy:
+      privacy_policy: https://silkky.cloud/privacy
       ddos_mitm_protection:
-      owner: https://github.com/TheSilkky
+      owner: https://github.com/silkkycloud
       is_modified:
       source:
       notes: 
@@ -215,7 +215,7 @@ instances:
     - url: https://invidious.hub.ne.kr
       country: SG
       status: 
-      privacy_policy:
+      privacy_policy: https://privacy.osbusiness.net/
       ddos_mitm_protection: null
       owner: https://github.com/hys0star
       is_modified:

--- a/instances.yaml
+++ b/instances.yaml
@@ -31,7 +31,6 @@ instances:
     #   is_modified: false
     #   source: null
 
-
     - url: https://invidious.snopyta.org
       country: FI
       status:
@@ -115,12 +114,11 @@ instances:
       is_modified: false
       source: null
 
-
     - url: https://invidious.exonip.de
       country: DE
       status: 
         url: https://status.exonip.de/
-        display_content:  Uptime Robot status
+        display_content: Status Page
         display_content_is_image: False
       privacy_policy:
       ddos_mitm_protection:
@@ -164,7 +162,6 @@ instances:
       is_modified: false
       source: null
 
-
     - url: https://yt.cyberhost.uk/
       country: FI
       status: 
@@ -179,7 +176,6 @@ instances:
       is_modified: false
       source: null
 
-
     - url: https://y.com.cm/
       country: DE
       status: 
@@ -188,6 +184,16 @@ instances:
       owner: https://github.com/Showfom
       is_modified: false
       source: null
+            
+    - url: https://invidious.hub.ne.kr
+      country: SG
+      status: 
+      privacy_policy:
+      ddos_mitm_protection: null
+      owner: https://github.com/hys0star
+      is_modified: false
+      source: null
+
 
   onion:
     # Template onion instance
@@ -239,3 +245,28 @@ instances:
       owner: https://github.com/FireMasterK
       is_modified: false
       source: null
+      
+    - url: http://xinzguzyta7riddeoygku6btmm3mdryxtfzwwjxy3zqpoxk3xg5qq6ad.onion
+      country: DE
+      associated_clearnet_instance: https://invidious.moomoo.me
+      privacy_policy:
+      owner: https://github.com/moom0o
+      is_modified: false
+      source: null
+
+    - url: http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/
+      country: DE
+      associated_clearnet_instance: https://invidious.exonip.de
+      privacy_policy:
+      owner: https://github.com/Exonip
+      is_modified: True
+      source: https://github.com/exonip-de/invidious-source-modifications
+
+    - url: http://vrg2a4cdxlngik5fkx6hbkslmd6yybsnot5bcegx6cfc7xja2t4r4zqd.onion
+      country: SG
+      associated_clearnet_instance: https://invidious.hub.ne.kr
+      privacy_policy:
+      owner: https://github.com/hys0star
+      is_modified: false
+      source: null
+

--- a/instances.yaml
+++ b/instances.yaml
@@ -43,6 +43,7 @@ instances:
       owner: https://github.com/Perflyst
       is_modified: false
       source: null
+      notes:
 
     - url: https://yewtu.be
       country: FR
@@ -52,6 +53,7 @@ instances:
       owner: https://github.com/unixfox
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious.kavin.rocks
       country: IN
@@ -65,6 +67,7 @@ instances:
       owner: https://github.com/FireMasterK
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious-us.kavin.rocks
       country: US
@@ -78,6 +81,7 @@ instances:
       owner: https://github.com/FireMasterK
       is_modified: false
       source: null
+      notes:
 
     - url: https://vid.puffyan.us
       country: US
@@ -91,6 +95,7 @@ instances:
       owner: https://github.com/ItsSt0ne
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious.namazso.eu
       country: DE
@@ -100,6 +105,7 @@ instances:
       owner: https://github.com/namazso
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious.silkky.cloud
       country: FI
@@ -113,6 +119,8 @@ instances:
       owner: https://github.com/TheSilkky
       is_modified: false
       source: null
+      notes: 
+        - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
 
     - url: https://invidious.exonip.de
       country: DE
@@ -125,6 +133,8 @@ instances:
       owner: https://github.com/Exonip
       is_modified: True
       source: https://github.com/exonip-de/invidious-source-modifications
+      notes: 
+        - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
 
     - url: https://inv.riverside.rocks
       country: US
@@ -134,6 +144,7 @@ instances:
       owner: https://github.com/RiversideRocks
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious.blamefran.net
       country: US
@@ -143,6 +154,7 @@ instances:
       owner: https://github.com/Aidan16
       is_modified: false
       source: null
+      notes:
 
     - url: https://invidious.moomoo.me
       country: DE
@@ -152,6 +164,7 @@ instances:
       owner: https://github.com/moom0o
       is_modified: false
       source: null
+      notes:
 
     - url: https://ytb.trom.tf
       country: DE
@@ -161,6 +174,7 @@ instances:
       owner: https://github.com/TROMsite
       is_modified: false
       source: null
+      notes:
 
     - url: https://yt.cyberhost.uk/
       country: FI
@@ -175,6 +189,7 @@ instances:
       modified:
       is_modified: false
       source: null
+      notes:
 
     - url: https://y.com.cm/
       country: DE
@@ -184,7 +199,8 @@ instances:
       owner: https://github.com/Showfom
       is_modified: false
       source: null
-            
+      notes:
+  
     - url: https://invidious.hub.ne.kr
       country: SG
       status: 
@@ -193,6 +209,7 @@ instances:
       owner: https://github.com/hys0star
       is_modified: false
       source: null
+      notes:
 
 
   onion:
@@ -213,6 +230,7 @@ instances:
       owner: https://github.com/Perflyst
       is_modified: false
       source: null
+      notes:
 
     - url: http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/
       country: IN
@@ -221,6 +239,7 @@ instances:
       owner: https://github.com/FireMasterK
       is_modified: false
       source: null
+      notes:
 
     - url: http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/
       country: NL
@@ -229,6 +248,7 @@ instances:
       owner: https://github.com/tirz
       is_modified: false
       source: null
+      notes:
 
     - url: http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/
       country: US
@@ -237,6 +257,7 @@ instances:
       owner: https://github.com/ItsSt0ne
       is_modified: false
       source: null
+      notes:
 
     - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
       country: US
@@ -245,7 +266,8 @@ instances:
       owner: https://github.com/FireMasterK
       is_modified: false
       source: null
-      
+      notes:
+
     - url: http://xinzguzyta7riddeoygku6btmm3mdryxtfzwwjxy3zqpoxk3xg5qq6ad.onion
       country: DE
       associated_clearnet_instance: https://invidious.moomoo.me
@@ -253,6 +275,7 @@ instances:
       owner: https://github.com/moom0o
       is_modified: false
       source: null
+      notes:
 
     - url: http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/
       country: DE
@@ -261,6 +284,7 @@ instances:
       owner: https://github.com/Exonip
       is_modified: True
       source: https://github.com/exonip-de/invidious-source-modifications
+      notes:
 
     - url: http://vrg2a4cdxlngik5fkx6hbkslmd6yybsnot5bcegx6cfc7xja2t4r4zqd.onion
       country: SG
@@ -269,4 +293,5 @@ instances:
       owner: https://github.com/hys0star
       is_modified: false
       source: null
+      notes:
 

--- a/instances.yaml
+++ b/instances.yaml
@@ -280,7 +280,7 @@ instances:
       status:
         image: https://status-image.example.com 
         text: Status Page
-      privacy_policy:
+      privacy_policy: https://snopyta.org/privacy_policy
       owner: https://github.com/Perflyst
       is_modified:
       source:

--- a/instances.yaml
+++ b/instances.yaml
@@ -22,22 +22,26 @@ instances:
     #   country: FI
     #   status: 
     #     url: https://status.example.com
-    #     display_content: https://status-image.example.com
-    #     display_content_is_image: True
-    #     display_content_image_fallback: uptime status
+    #     image: https://status-image.example.com 
+    #     text: Status Page
     #   privacy_policy: example.com/privacy
-    #   ddos_mitm_protection: null
+    #   ddos_mitm_protection:
     #   owner: https://github.com/example
-    #   is_modified: false
-    #   source: null
+    #   is_modified:
+    #   source:
+    #   notes:
+    #     _  Hi I am an example!
+    # 
+    # *Image attribute in status has higher prioirty than text. Thus, if this attribute is filled out
+    #  The text attribute would only be used as a fallback.
+
 
     - url: https://invidious.snopyta.org
       country: FI
       status:
         url: https://status.unixfox.eu/783898765
-        display_content: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
+        text: Uptime Robot status
       privacy_policy: https://snopyta.org/privacy_policy
       ddos_mitm_protection: null
       owner: https://github.com/Perflyst
@@ -59,9 +63,8 @@ instances:
       country: IN
       status:
         url: https://status.kavin.rocks/786132664
-        display_content: https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image: https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71
+        text: Uptime Robot status
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
@@ -73,9 +76,8 @@ instances:
       country: US
       status: 
         url: https://status.kavin.rocks/788216947
-        display_content: https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image: https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a
+        text: Uptime Robot status
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
@@ -87,9 +89,8 @@ instances:
       country: US
       status: 
         url: https://stats.uptimerobot.com/n7A08HGVl6/786947233
-        display_content: https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image: https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3
+        text: Uptime Robot status
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/ItsSt0ne
@@ -111,9 +112,8 @@ instances:
       country: FI
       status: 
         url: https://status.silkky.cloud/787784614
-        display_content:  https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image:  https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793
+        text: Uptime Robot status
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TheSilkky
@@ -126,8 +126,7 @@ instances:
       country: DE
       status: 
         url: https://status.exonip.de/
-        display_content: Status Page
-        display_content_is_image:
+        text: Status Page
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Exonip
@@ -180,9 +179,8 @@ instances:
       country: FI
       status: 
         url: https://stats.uptimerobot.com/JlM0qH8Ygn
-        display_content: https://img.shields.io/uptimerobot/status/m788432154-c8801112193f349268ea6104
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
+        image: https://img.shields.io/uptimerobot/status/m788432154-c8801112193f349268ea6104
+        text: Uptime Robot status
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/cyberhost-uk
@@ -236,6 +234,9 @@ instances:
     - url: http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion
       country: FI
       associated_clearnet_instance: https://invidious.snopyta.org
+      status:
+        image: https://status-image.example.com 
+        text: Status Page
       privacy_policy:
       owner: https://github.com/Perflyst
       is_modified:

--- a/instances.yaml
+++ b/instances.yaml
@@ -8,6 +8,7 @@ adding_instance:
     - Instances using any type of anti-bot protection are marked as such.
     - "Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it."
     - Instances running a modified source code must respect the AGPL by publishing their source code and stating their changes before they are be added to the list, and must publish any later modification in a timely manner.
+    - - The instance must also contain a link to *both* the modified and original source code of Invidious. Ideally in the footer.
     - Instances should be up and functional at least 90% of the time.
   directions:
     - Fork the documentation repo.
@@ -51,7 +52,10 @@ instances:
 
     - url: https://yewtu.be
       country: FR
-      status: null
+      status:
+        url: https://uptime.invidious.io/784257752
+        image: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
+        text: Uptime Robot status
       privacy_policy: null
       ddos_mitm_protection: null
       owner: https://github.com/unixfox
@@ -85,6 +89,19 @@ instances:
       source:
       notes:
 
+    - url: https://invidious-jp.kavin.rocks
+      country: JP
+      status: 
+        url: https://status.kavin.rocks/788866642
+        image: https://img.shields.io/uptimerobot/status/m788866642-8a4478b8853722e98b7634e9
+        text: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: Cloudflare
+      owner: https://github.com/FireMasterK
+      is_modified:
+      source:
+      notes:
+
     - url: https://vid.puffyan.us
       country: US
       status: 
@@ -96,6 +113,19 @@ instances:
       owner: https://github.com/ItsSt0ne
       is_modified:
       source:
+      notes:
+
+    - url: https://ytprivate.com
+      country: US
+      status: 
+        url: https://status.ytprivate.com/786947505
+        image: https://img.shields.io/uptimerobot/status/m786947505-2a50cf3262906bb28c6cf8fc
+        text: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: DDoS-Guard
+      owner: https://github.com/ytprivatecom
+      is_modified: true
+      source: https://github.com/ytprivatecom/invidious
       notes:
 
     - url: https://invidious.namazso.eu
@@ -155,38 +185,14 @@ instances:
       source:
       notes:
 
-    - url: https://invidious.moomoo.me
-      country: DE
-      status:
-      privacy_policy:
-      ddos_mitm_protection: Cloudflare
-      owner: https://github.com/moom0o
-      is_modified:
-      source:
-      notes:
-
     - url: https://ytb.trom.tf
       country: DE
       status:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TROMsite
-      is_modified:
-      source:
-      notes:
-
-    - url: https://yt.cyberhost.uk/
-      country: FI
-      status: 
-        url: https://stats.uptimerobot.com/JlM0qH8Ygn
-        image: https://img.shields.io/uptimerobot/status/m788432154-c8801112193f349268ea6104
-        text: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection:
-      owner: https://github.com/cyberhost-uk
-      modified:
-      is_modified:
-      source:
+      is_modified: True
+      source: https://gitlab.com/TioTrom/trom.tf-invidious
       notes:
 
     - url: https://y.com.cm/
@@ -202,6 +208,8 @@ instances:
     - url: https://invidious.s1gm4.eu
       country: FR
       status: 
+        url: https://status.s1gm4.eu/
+        text: Status Page
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/OrnithOrtion
@@ -217,6 +225,42 @@ instances:
       owner: https://github.com/hys0star
       is_modified:
       source:
+      notes:
+
+    - url: https://invidious.noho.st
+      country: GB
+      status: 
+        url: https://img.shields.io/uptimerobot/status/m788769382-1b3bca2509f1d891c4620dbe
+        image: https://img.shields.io/uptimerobot/status/m788769382-1b3bca2509f1d891c4620dbe
+        text: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: null
+      owner: https://github.com/tomaytotomato
+      is_modified:
+      source:
+      notes:
+
+    - url: https://invidio.xamh.de
+      country: DE
+      status: 
+        url: https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8
+        image: https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8
+        text: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection: null
+      owner: https://github.com/11Tuvork28
+      is_modified:
+      source:
+      notes:
+
+    - url: https://youtube.076.ne.jp
+      country: JP
+      status: 
+      privacy_policy:
+      ddos_mitm_protection: null
+      owner: https://github.com/TechnicalSuwako
+      is_modified: True
+      source: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
       notes:
 
 
@@ -279,15 +323,6 @@ instances:
       source:
       notes:
 
-    - url: http://xinzguzyta7riddeoygku6btmm3mdryxtfzwwjxy3zqpoxk3xg5qq6ad.onion
-      country: DE
-      associated_clearnet_instance: https://invidious.moomoo.me
-      privacy_policy:
-      owner: https://github.com/moom0o
-      is_modified:
-      source:
-      notes:
-
     - url: http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/
       country: DE
       associated_clearnet_instance: https://invidious.exonip.de
@@ -297,7 +332,7 @@ instances:
       source: https://github.com/exonip-de/invidious-source-modifications
       notes:
 
-    - url: http://vrg2a4cdxlngik5fkx6hbkslmd6yybsnot5bcegx6cfc7xja2t4r4zqd.onion
+    - url: http://pwo2md4lgxs3hvroqi6wg33h6a3pv47euax6km3alke7letglieokyd.onion
       country: SG
       associated_clearnet_instance: https://invidious.hub.ne.kr
       privacy_policy:

--- a/instances.yaml
+++ b/instances.yaml
@@ -19,9 +19,7 @@ instances:
   https:
     # Template instance
     # - url: https://example.com
-    #   country:
-    #     flag: 🇫🇮
-    #     name: Finland
+    #   country: FI
     #   status: 
     #     url: https://status.example.com
     #     display_content: https://status-image.example.com
@@ -30,16 +28,13 @@ instances:
     #   privacy_policy: example.com/privacy
     #   ddos_mitm_protection: null
     #   owner: https://github.com/example
-    #   modified:
-    #     is_modified: False
-    #     source_url: null
+    #   is_modified: false
+    #   source: null
 
 
     - url: https://invidious.snopyta.org
-      country:
-        flag: 🇫🇮
-        name: Finland
-      status: 
+      country: FI
+      status:
         url: https://status.unixfox.eu/783898765
         display_content: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
         display_content_is_image: True
@@ -47,26 +42,20 @@ instances:
       privacy_policy: https://snopyta.org/privacy_policy
       ddos_mitm_protection: null
       owner: https://github.com/Perflyst
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://yewtu.be
-      country:
-        flag: 🇫🇷
-        name: France
+      country: FR
       status: null
       privacy_policy: null
       ddos_mitm_protection: null
       owner: https://github.com/unixfox
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://invidious.kavin.rocks
-      country:
-        flag: 🇮🇳
-        name: India
+      country: IN
       status:
         url: https://status.kavin.rocks/786132664
         display_content: https://img.shields.io/uptimerobot/status/m786132664-f9fa738fba1c4dc2f7364f71
@@ -75,14 +64,11 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://invidious-us.kavin.rocks
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       status: 
         url: https://status.kavin.rocks/788216947
         display_content: https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a
@@ -91,30 +77,11 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
-      modified:
-        is_modified: False
-        source_url: null
-
-    - url: https://invidious.048596.xyz
-      country:
-        flag: 🇨🇦
-        name: Canada
-      status: 
-        url: https://status.048596.xyz/786792286
-        display_content: https://img.shields.io/uptimerobot/status/m786792286-b5894e4e11c42b8332375076
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection:
-      owner: https://github.com/tenpura-shrimp
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://vid.puffyan.us
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       status: 
         url: https://stats.uptimerobot.com/n7A08HGVl6/786947233
         display_content: https://img.shields.io/uptimerobot/status/m786947233-1131c3f67b9a20621b1926d3
@@ -123,42 +90,20 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/ItsSt0ne
-      modified:
-        is_modified: False
-        source_url: null
-
-    - url: https://ytprivate.com
-      country:
-        flag: 🇺🇸
-        name: USA
-      status: 
-        url: https://status.ytprivate.com/786947505
-        display_content:  https://img.shields.io/uptimerobot/status/m786947505-2a50cf3262906bb28c6cf8fc
-        display_content_is_image: True
-        display_content_image_fallback: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection: DDoS-Guard
-      owner: https://github.com/ytprivatecom
-      modified:
-        is_modified: True
-        source_url: https://github.com/ytprivatecom/invidious
+      is_modified: false
+      source: null
 
     - url: https://invidious.namazso.eu
-      country:
-        flag: 🇩🇪
-        name: Germany
+      country: DE
       status: 
       privacy_policy: https://namazso.eu/privacy.html
       ddos_mitm_protection:
       owner: https://github.com/namazso
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://invidious.silkky.cloud
-      country:
-        flag: 🇫🇮
-        name: Finland
+      country: FI
       status: 
         url: https://status.silkky.cloud/787784614
         display_content:  https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793
@@ -167,14 +112,12 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TheSilkky
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
+
 
     - url: https://invidious.exonip.de
-      country:
-        flag: 🇩🇪
-        name: Germany
+      country: DE
       status: 
         url: https://status.exonip.de/
         display_content:  Uptime Robot status
@@ -182,65 +125,48 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Exonip
-      modified:
-        is_modified: True
-        source_url: https://github.com/exonip-de/invidious-source-modifications
+      is_modified: True
+      source: https://github.com/exonip-de/invidious-source-modifications
 
     - url: https://inv.riverside.rocks
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       status:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/RiversideRocks
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://invidious.blamefran.net
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       status:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Aidan16
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: https://invidious.moomoo.me
-      country:
-        flag: 🇩🇪
-        name: Germany
+      country: DE
       status:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/moom0o
-      modified:
-        is_modified: False
-        source_url: null 
-
+      is_modified: false
+      source: null
 
     - url: https://ytb.trom.tf
-
-      country:
-        flag: 🇩🇪
-        name: Germany
+      country: DE
       status:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TROMsite
-      modified:
-        is_modified: False
-        source_url: null 
+      is_modified: false
+      source: null
 
 
     - url: https://yt.cyberhost.uk/
-      country:
-        flag: 🇫🇮
-        name: Finland
+      country: FI
       status: 
         url: https://stats.uptimerobot.com/JlM0qH8Ygn
         display_content: https://img.shields.io/uptimerobot/status/m788432154-c8801112193f349268ea6104
@@ -250,86 +176,66 @@ instances:
       ddos_mitm_protection:
       owner: https://github.com/cyberhost-uk
       modified:
-        is_modified: False
-        source_url: null 
+      is_modified: false
+      source: null
 
 
     - url: https://y.com.cm/
-      country:
-        flag: 🇩🇪
-        name: Germany
+      country: DE
       status: 
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/Showfom
-      modified:
-        is_modified: False
-        source_url: null 
+      is_modified: false
+      source: null
 
   onion:
     # Template onion instance
-    # - url: http://example.onion
-    #   country:
-    #     flag: 🇺🇸
-    #     name: USA
+    #   url: http://example.onion
+    #   country: FI
     #   associated_clearnet_instance: https://example.com
     #   privacy_policy: https://privacy.example.com
     #   owner: https://github.com/example
     #   modified:
-    #     is_modified: False
-    #     source_url: null
+    #   is_modified: false
+    #   source: null
 
     - url: http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion
-      country:
-        flag: 🇫🇮
-        name: Finland
+      country: FI
       associated_clearnet_instance: https://invidious.snopyta.org
       privacy_policy:
       owner: https://github.com/Perflyst
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/
-      country:
-        flag: 🇮🇳
-        name: India
+      country: IN
       associated_clearnet_instance: https://invidious.kavin.rocks
       privacy_policy:
       owner: https://github.com/FireMasterK
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/
-      country:
-        flag: 🇳🇱
-        name: Netherlands
+      country: NL
       associated_clearnet_instance:
       privacy_policy:
       owner: https://github.com/tirz
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       associated_clearnet_instance: https://vid.puffyan.us
       privacy_policy:
       owner: https://github.com/ItsSt0ne
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null
 
     - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
-      country:
-        flag: 🇺🇸
-        name: USA
+      country: US
       associated_clearnet_instance: https://invidious-us.kavin.rocks/
       privacy_policy:
       owner: https://github.com/FireMasterK
-      modified:
-        is_modified: False
-        source_url: null
+      is_modified: false
+      source: null

--- a/instances.yaml
+++ b/instances.yaml
@@ -49,8 +49,7 @@ instances:
       privacy_policy: https://snopyta.org/privacy_policy
       ddos_mitm_protection: null
       owner: https://github.com/Perflyst
-      is_modified:
-      source:
+      modified:
       notes:
       mirrors:
 
@@ -63,8 +62,7 @@ instances:
       privacy_policy: null
       ddos_mitm_protection: null
       owner: https://github.com/unixfox
-      is_modified:
-      source:
+      modified:
       notes:
       mirrors:
 
@@ -77,8 +75,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/FireMasterK
-      is_modified:
-      source:
+      modified:
       notes:
       mirrors:
         - url: https://invidious-us.kavin.rocks
@@ -96,8 +93,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/ItsSt0ne
-      is_modified:
-      source:
+      modified:
       notes:
       mirrors:
 
@@ -110,8 +106,9 @@ instances:
       privacy_policy:
       ddos_mitm_protection: DDoS-Guard
       owner: https://github.com/ytprivatecom
-      is_modified: true
-      source: https://github.com/ytprivatecom/invidious
+      modified:
+        source: https://github.com/ytprivatecom/invidious
+        changes: https://github.com/ytprivatecom/invidious#source-changes
       notes:
       mirrors:
 
@@ -121,7 +118,7 @@ instances:
       privacy_policy: https://namazso.eu/privacy.html
       ddos_mitm_protection:
       owner: https://github.com/namazso
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -135,7 +132,7 @@ instances:
       privacy_policy: https://silkky.cloud/privacy
       ddos_mitm_protection:
       owner: https://github.com/silkkycloud
-      is_modified:
+      modified:
       source:
       notes: 
         - "[Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
@@ -149,8 +146,9 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Exonip
-      is_modified: True
-      source: https://github.com/exonip-de/invidious-source-modifications
+      modified:
+        source: https://github.com/exonip-de/invidious-source-modifications
+        changes: https://github.com/exonip-de/invidious-source-modifications
       notes: 
         - "[Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
       mirrors:
@@ -161,7 +159,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/RiversideRocks
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -172,7 +170,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/Aidan16
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -183,8 +181,9 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/TROMsite
-      is_modified: True
-      source: https://gitlab.com/TioTrom/trom.tf-invidious
+      modified:
+        source: https://gitlab.com/TioTrom/trom.tf-invidious
+        changes: https://gitlab.com/TioTrom/trom.tf-invidious
       notes:
       mirrors:
 
@@ -194,8 +193,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/Showfom
-      is_modified:
-      source:
+      modified:
       notes:
       mirrors:
 
@@ -207,7 +205,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection:
       owner: https://github.com/OrnithOrtion
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -218,7 +216,7 @@ instances:
       privacy_policy: https://privacy.osbusiness.net/
       ddos_mitm_protection: null
       owner: https://github.com/hys0star
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -232,7 +230,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection: null
       owner: https://github.com/tomaytotomato
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -246,7 +244,7 @@ instances:
       privacy_policy:
       ddos_mitm_protection: null
       owner: https://github.com/11Tuvork28
-      is_modified:
+      modified:
       source:
       notes:
       mirrors:
@@ -257,8 +255,9 @@ instances:
       privacy_policy:
       ddos_mitm_protection: null
       owner: https://github.com/TechnicalSuwako
-      is_modified: True
-      source: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
+      modified:
+        source: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
+        changes: https://git.076.ne.jp/TechnicalSuwako/invidious-mod#change
       notes:
       mirrors:
 
@@ -282,7 +281,7 @@ instances:
         text: Status Page
       privacy_policy: https://snopyta.org/privacy_policy
       owner: https://github.com/Perflyst
-      is_modified:
+      modified:
       source:
       notes:
       mirrors: 
@@ -292,7 +291,7 @@ instances:
       associated_clearnet_instance: https://invidious.kavin.rocks
       privacy_policy:
       owner: https://github.com/FireMasterK
-      is_modified:
+      modified:
       source:
       notes:
       mirrors: 
@@ -307,7 +306,7 @@ instances:
       associated_clearnet_instance:
       privacy_policy:
       owner: https://github.com/tirz
-      is_modified:
+      modified:
       source:
       notes:
       mirrors: 
@@ -317,7 +316,7 @@ instances:
       associated_clearnet_instance: https://vid.puffyan.us
       privacy_policy:
       owner: https://github.com/ItsSt0ne
-      is_modified:
+      modified:
       source:
       notes:
       mirrors: 
@@ -327,8 +326,9 @@ instances:
       associated_clearnet_instance: https://invidious.exonip.de
       privacy_policy:
       owner: https://github.com/Exonip
-      is_modified: True
-      source: https://github.com/exonip-de/invidious-source-modifications
+      modified:
+        source: https://github.com/exonip-de/invidious-source-modifications
+        changes: https://github.com/exonip-de/invidious-source-modifications
       notes:
       mirrors:
 
@@ -337,7 +337,7 @@ instances:
       associated_clearnet_instance: https://invidious.hub.ne.kr
       privacy_policy:
       owner: https://github.com/hys0star
-      is_modified:
+      modified:
       source:
       notes:
       mirrors: 

--- a/instances.yaml
+++ b/instances.yaml
@@ -32,6 +32,9 @@ instances:
     #   source:
     #   notes:
     #     _  Hi I am an example!
+    #   mirrors: # Mirrors should follow a reduced syntax of the base instance
+    #     - url: https://us.example.com
+    #     - country: US
     # 
     # *Image attribute in status has higher prioirty than text. Thus, if this attribute is filled out
     #  The text attribute would only be used as a fallback.
@@ -49,6 +52,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://yewtu.be
       country: FR
@@ -62,6 +66,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidious.kavin.rocks
       country: IN
@@ -75,32 +80,12 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
+        - url: https://invidious-us.kavin.rocks
+          country: US
 
-    - url: https://invidious-us.kavin.rocks
-      country: US
-      status: 
-        url: https://status.kavin.rocks/788216947
-        image: https://img.shields.io/uptimerobot/status/m788216947-f3f63d30899a10dbe9a0338a
-        text: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection: Cloudflare
-      owner: https://github.com/FireMasterK
-      is_modified:
-      source:
-      notes:
-
-    - url: https://invidious-jp.kavin.rocks
-      country: JP
-      status: 
-        url: https://status.kavin.rocks/788866642
-        image: https://img.shields.io/uptimerobot/status/m788866642-8a4478b8853722e98b7634e9
-        text: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection: Cloudflare
-      owner: https://github.com/FireMasterK
-      is_modified:
-      source:
-      notes:
+        - url: https://invidious-jp.kavin.rocks
+          country: JP
 
     - url: https://vid.puffyan.us
       country: US
@@ -114,6 +99,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://ytprivate.com
       country: US
@@ -127,6 +113,7 @@ instances:
       is_modified: true
       source: https://github.com/ytprivatecom/invidious
       notes:
+      mirrors:
 
     - url: https://invidious.namazso.eu
       country: DE
@@ -137,6 +124,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidious.silkky.cloud
       country: FI
@@ -151,6 +139,7 @@ instances:
       source:
       notes: 
         - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
+      mirrors:
 
     - url: https://invidious.exonip.de
       country: DE
@@ -164,6 +153,7 @@ instances:
       source: https://github.com/exonip-de/invidious-source-modifications
       notes: 
         - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
+      mirrors:
 
     - url: https://inv.riverside.rocks
       country: US
@@ -174,6 +164,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidious.blamefran.net
       country: US
@@ -184,6 +175,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://ytb.trom.tf
       country: DE
@@ -194,6 +186,7 @@ instances:
       is_modified: True
       source: https://gitlab.com/TioTrom/trom.tf-invidious
       notes:
+      mirrors:
 
     - url: https://y.com.cm/
       country: DE
@@ -204,6 +197,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidious.s1gm4.eu
       country: FR
@@ -216,7 +210,8 @@ instances:
       is_modified:
       source:
       notes:
-  
+      mirrors:
+
     - url: https://invidious.hub.ne.kr
       country: SG
       status: 
@@ -226,6 +221,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidious.noho.st
       country: GB
@@ -239,6 +235,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://invidio.xamh.de
       country: DE
@@ -252,6 +249,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors:
 
     - url: https://youtube.076.ne.jp
       country: JP
@@ -262,6 +260,7 @@ instances:
       is_modified: True
       source: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
       notes:
+      mirrors:
 
 
   onion:

--- a/instances.yaml
+++ b/instances.yaml
@@ -183,8 +183,8 @@ instances:
       ddos_mitm_protection:
       owner: https://github.com/Exonip
       modified:
-        is_modified: False
-        source_url: null
+        is_modified: True
+        source_url: https://github.com/exonip-de/invidious-source-modifications
 
     - url: https://inv.riverside.rocks
       country:

--- a/instances.yaml
+++ b/instances.yaml
@@ -10,7 +10,7 @@ adding_instance:
     - Instances running a modified source code must respect the AGPL by publishing their source code and stating their changes before they are be added to the list, and must publish any later modification in a timely manner.
   directions:
     - Fork the documentation repo.
-    - Open `instances.yaml` for editing."
+    - Open `instances.yaml` for editing.
     - Append your instance to the bottom of the HTTPS (or onion) list. See the examples in the yaml file for more info.
     - Make a pull request.
 
@@ -217,6 +217,18 @@ instances:
         is_modified: False
         source_url: null
 
+    - url: https://invidious.moomoo.me
+      country:
+        flag: 🇩🇪
+        name: Germany
+      status:
+      privacy_policy:
+      ddos_mitm_protection: Cloudflare
+      owner: https://github.com/moom0o
+      modified:
+        is_modified: False
+        source_url: null 
+
   onion:
     # Template onion instance
     # - url: http://example.onion
@@ -234,7 +246,7 @@ instances:
       country:
         flag: 🇫🇮
         name: Finland
-      invidious.snopyta.org: invidious.snopyta.org
+      associated_clearnet_instance: https://invidious.snopyta.org
       privacy_policy:
       owner: https://github.com/Perflyst
       modified:

--- a/instances.yaml
+++ b/instances.yaml
@@ -3,7 +3,7 @@ adding_instance:
     - Instances must have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and is removed from the list.
     - Instances must have statistics (/api/v1/stats) enabled (statistics_enabled:true in the configuration file)
     - Instances must be served via domain name.
-    - Instances must be served via domain name.
+    - Instances must be served via HTTPS.
     - Instances using any DDoS Protection / MITM are marked as such.
     - Instances using any type of anti-bot protection are marked as such.
     - "Instances using any type of analytics are marked as such, must be GDPR compliant (if it's usable in the EU), must be CCPA compliant (if it's usable in California), and must respect the AGPL by explaining their changes and by publishing their source code. In short: instances shouldn't run analytics, because it's not worth it."
@@ -17,13 +17,17 @@ adding_instance:
 instances:
   https:
     # Template instance
-    # - url: example.com
+    # - url: https://example.com
     #   country:
     #     flag: 🇫🇮
     #     name: Finland
-    #   status_url: status.example.com
-    #   privacy_policy: privacy.example.com
-    #   ddos_mitm_protection: Cloudflare
+    #   status: 
+    #     url: https://status.example.com
+    #     display_content: https://status-image.example.com
+    #     display_content_is_image: True
+    #     display_content_image_fallback: uptime status
+    #   privacy_policy: example.com/privacy
+    #   ddos_mitm_protection: null
     #   owner: https://github.com/example
     #   modified:
     #     is_modified: False
@@ -235,8 +239,8 @@ instances:
     #   country:
     #     flag: 🇺🇸
     #     name: USA
-    #   associated_clearnet_instance: example.com
-    #   privacy_policy: privacy.example.com
+    #   associated_clearnet_instance: https://example.com
+    #   privacy_policy: https://privacy.example.com
     #   owner: https://github.com/example
     #   modified:
     #     is_modified: False

--- a/instances.yaml
+++ b/instances.yaml
@@ -54,7 +54,7 @@ instances:
       mirrors:
 
     - url: https://yewtu.be
-      country: FR
+      country: NE
       status:
         url: https://uptime.invidious.io/784257752
         image: https://img.shields.io/uptimerobot/status/m783898765-2a4efa67aa8d1c7be6b1dd9d
@@ -164,12 +164,14 @@ instances:
       notes:
       mirrors:
 
-    - url: https://invidious.blamefran.net
-      country: US
-      status:
+    - url: https://vid.mint.lgbt/
+      country: CA
+      status: 
+        url: https://status.mint.lgbt/service/lesvidious
+        text: Status Page
       privacy_policy:
       ddos_mitm_protection:
-      owner: https://github.com/Aidan16
+      owner: https://github.com/mintphin
       modified:
       source:
       notes:
@@ -197,39 +199,12 @@ instances:
       notes:
       mirrors:
 
-    - url: https://invidious.s1gm4.eu
-      country: FR
-      status: 
-        url: https://status.s1gm4.eu/
-        text: Status Page
-      privacy_policy:
-      ddos_mitm_protection:
-      owner: https://github.com/OrnithOrtion
-      modified:
-      source:
-      notes:
-      mirrors:
-
     - url: https://invidious.hub.ne.kr
-      country: SG
+      country: KR
       status: 
       privacy_policy: https://privacy.osbusiness.net/
       ddos_mitm_protection: null
       owner: https://github.com/hys0star
-      modified:
-      source:
-      notes:
-      mirrors:
-
-    - url: https://invidious.noho.st
-      country: GB
-      status: 
-        url: https://img.shields.io/uptimerobot/status/m788769382-1b3bca2509f1d891c4620dbe
-        image: https://img.shields.io/uptimerobot/status/m788769382-1b3bca2509f1d891c4620dbe
-        text: Uptime Robot status
-      privacy_policy:
-      ddos_mitm_protection: null
-      owner: https://github.com/tomaytotomato
       modified:
       source:
       notes:
@@ -251,13 +226,23 @@ instances:
 
     - url: https://youtube.076.ne.jp
       country: JP
-      status: 
+      status:
       privacy_policy:
       ddos_mitm_protection: null
       owner: https://github.com/TechnicalSuwako
       modified:
         source: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
         changes: https://git.076.ne.jp/TechnicalSuwako/invidious-mod#change
+      notes:
+      mirrors:
+
+    - url: https://yt.didw.to/
+      country: SE
+      status: 
+      privacy_policy:
+      ddos_mitm_protection: null
+      owner: https://github.com/didw-to
+      modified:
       notes:
       mirrors:
 
@@ -333,10 +318,20 @@ instances:
       mirrors:
 
     - url: http://pwo2md4lgxs3hvroqi6wg33h6a3pv47euax6km3alke7letglieokyd.onion
-      country: SG
+      country: KR
       associated_clearnet_instance: https://invidious.hub.ne.kr
       privacy_policy:
       owner: https://github.com/hys0star
+      modified:
+      source:
+      notes:
+      mirrors: 
+
+    - url: http://k7mnd6gyelynroxoncodxjz44fd5ch2ewfjl2a6ozmg3jy6fwyxq3cyd.onion/ 
+      country: SE
+      associated_clearnet_instance: https://yt.didw.to/
+      privacy_policy:
+      owner: https://github.com/didw-to
       modified:
       source:
       notes:

--- a/instances.yaml
+++ b/instances.yaml
@@ -138,7 +138,7 @@ instances:
       is_modified:
       source:
       notes: 
-        - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
+        - "[Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
       mirrors:
 
     - url: https://invidious.exonip.de
@@ -152,7 +152,7 @@ instances:
       is_modified: True
       source: https://github.com/exonip-de/invidious-source-modifications
       notes: 
-        - "[Uses anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
+        - "[Anti-bot protection](https://github.com/bunkerity/bunkerized-nginx)"
       mirrors:
 
     - url: https://inv.riverside.rocks
@@ -285,6 +285,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors: 
 
     - url: http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/
       country: IN
@@ -294,6 +295,12 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors: 
+        - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
+          country: US
+
+        - url: http://p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion/
+          country: JP
 
     - url: http://kbjggqkzv65ivcqj6bumvp337z6264huv5kpkwuv6gu5yjiskvan7fad.onion/
       country: NL
@@ -303,6 +310,7 @@ instances:
       is_modified:
       source:
       notes:
+      mirrors: 
 
     - url: http://grwp24hodrefzvjjuccrkw3mjq4tzhaaq32amf33dzpmuxe7ilepcmad.onion/
       country: US
@@ -312,15 +320,7 @@ instances:
       is_modified:
       source:
       notes:
-
-    - url: http://hpniueoejy4opn7bc4ftgazyqjoeqwlvh2uiku2xqku6zpoa4bf5ruid.onion/
-      country: US
-      associated_clearnet_instance: https://invidious-us.kavin.rocks/
-      privacy_policy:
-      owner: https://github.com/FireMasterK
-      is_modified:
-      source:
-      notes:
+      mirrors: 
 
     - url: http://invidc4i7i5uci6cledxsao6w7ng5etpflagdzoxj3yhipztwzvqjryd.onion/
       country: DE
@@ -330,6 +330,7 @@ instances:
       is_modified: True
       source: https://github.com/exonip-de/invidious-source-modifications
       notes:
+      mirrors:
 
     - url: http://pwo2md4lgxs3hvroqi6wg33h6a3pv47euax6km3alke7letglieokyd.onion
       country: SG
@@ -339,13 +340,4 @@ instances:
       is_modified:
       source:
       notes:
-
-    - url: http://p4ozd76i5zmqepf6xavtehswcve2taptxbwpswkq5osfvncwylavllid.onion/
-      country: JP
-      associated_clearnet_instance: https://invidious-jp.kavin.rocks
-      privacy_policy:
-      owner: https://github.com/FireMasterK
-      is_modified:
-      source:
-      notes:
-
+      mirrors: 

--- a/instances.yaml
+++ b/instances.yaml
@@ -246,6 +246,16 @@ instances:
       notes:
       mirrors:
 
+    - url: https://yt.artemislena.eu
+      country: DE
+      status:
+      privacy_policy: https://artemislena.eu/privacy.html
+      ddos_mitm_protection: null
+      owner: https://github.com/artemislena
+      modified:
+      notes:
+      mirrors:
+
 
   onion:
     # Template onion instance

--- a/instances.yaml
+++ b/instances.yaml
@@ -185,18 +185,6 @@ instances:
         is_modified: False
         source_url: null
 
-    - url: https://notyoutube.org
-      country:
-        flag: 🇫🇮
-        name: Finland
-      status:
-      privacy_policy:
-      ddos_mitm_protection:
-      owner: https://github.com/Eggo-Plant
-      modified:
-        is_modified: False
-        source_url: null
-
     - url: https://inv.riverside.rocks
       country:
         flag: 🇺🇸
@@ -229,6 +217,50 @@ instances:
       privacy_policy:
       ddos_mitm_protection: Cloudflare
       owner: https://github.com/moom0o
+      modified:
+        is_modified: False
+        source_url: null 
+
+
+    - url: https://ytb.trom.tf
+
+      country:
+        flag: 🇩🇪
+        name: Germany
+      status:
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/TROMsite
+      modified:
+        is_modified: False
+        source_url: null 
+
+
+    - url: https://yt.cyberhost.uk/
+      country:
+        flag: 🇫🇮
+        name: Finland
+      status: 
+        url: https://stats.uptimerobot.com/JlM0qH8Ygn
+        display_content: https://img.shields.io/uptimerobot/status/m788432154-c8801112193f349268ea6104
+        display_content_is_image: True
+        display_content_image_fallback: Uptime Robot status
+      privacy_policy:
+      ddos_mitm_protection:
+      owner: https://github.com/cyberhost-uk
+      modified:
+        is_modified: False
+        source_url: null 
+
+
+    - url: https://y.com.cm/
+      country:
+        flag: 🇩🇪
+        name: Germany
+      status: 
+      privacy_policy:
+      ddos_mitm_protection: Cloudflare
+      owner: https://github.com/Showfom
       modified:
         is_modified: False
         source_url: null 

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -1,0 +1,92 @@
+"""Extremely quick and dirty module for creating a markdown file from the instances.yaml file"""
+from urllib.parse import urlparse
+
+import yaml
+from mdutils.mdutils import MdUtils
+
+
+def create_table(table_data, instance_data):
+    rows = []
+    for field, value in instance_data.items():
+        if value is None:
+            rows.append("")
+        
+        # Use markdown links for Addresses
+        elif field in ["url", "associated_clearnet_instance"]:
+            url = urlparse(value).hostname
+            rows.append(f"[{url}]({value})")
+
+        elif field == "status" and value is not None:
+            if value.get("display_content_is_image"):
+                rows.append(f"[![{value['display_content_image_fallback']}]({value['display_content']})]({value['url']})")
+            else:
+                rows.append(f"[{value['display_content']}]({value['url']})")
+        
+        elif field == "country" and value:
+            rows.append(f"{value['flag']} {value['name']}")
+
+        elif field == "modified":
+            if value.get("is_modified"):
+                rows.append(f"[Yes]({value['source_url']})")
+            else:
+                rows.append("No")
+
+        # We're going to use a markdown link here
+        elif field == "privacy_policy":
+            rows.append(f"[Here]({value})")
+
+        # Handle author name
+        elif field == "owner":
+            # Assuming github url
+            author_name = value.split("/")
+            rows.append(f"[@{author_name[-1]}]({value})")
+        else:
+            rows.append(value)
+
+    table_data.extend(rows)
+
+
+with open("instances.yaml") as configuration_yaml:
+    data = yaml.safe_load(configuration_yaml)
+
+instance_list = data["instances"]
+
+# Initial information
+md_instance_list = MdUtils(file_name='Invidious-Instances.md')
+md_instance_list.new_header(level=1, title='Public Instances')
+md_instance_list.new_paragraph("Uptime History: [uptime.invidious.io](https://uptime.invidious.io)")
+md_instance_list.new_paragraph("Instances API: [api.invidious.io](api.invidious.io)")
+
+
+# Clearnet instances
+md_instance_list.new_header(level=1, title='Instances list')
+table_data = ["Address", "Country", "Status", "Privacy policy", "DDos Protection / MITM", "Owner", "Modified"]
+for instance_data in instance_list["https"]:
+    create_table(table_data, instance_data)
+
+md_instance_list.new_line()
+md_instance_list.new_table(columns=7, rows=len(instance_list["https"]) + 1, text=table_data, text_align='center')
+
+
+# Onion instances
+md_instance_list.new_header(level=1, title='Tor onion instances list')
+table_data = ["Address", "Country", "Associated clearnet instance", "Privacy policy", "Owner", "Modified"]
+for instance_data in instance_list["onion"]:
+    create_table(table_data, instance_data) 
+
+md_instance_list.new_line()
+md_instance_list.new_table(columns=6, rows=len(instance_list["onion"]) + 1, text=table_data, text_align='center')
+
+
+# Instance adding directions and prerequisites
+md_instance_list.new_header(level=1, title='Adding your instance')
+
+# Prerequisites
+md_instance_list.new_header(level=2, title='Prerequisites')
+md_instance_list.new_list(data["adding_instance"]["prerequisites"])
+md_instance_list.new_line()
+
+# Directions
+md_instance_list.new_header(level=2, title='Directions')
+md_instance_list.new_list(data["adding_instance"]["directions"], marked_with="1")
+md_instance_list.create_md_file()

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -46,14 +46,13 @@ class ColumnBuilder:
             return ""
 
         status_url = status_dict["url"]
-        display_content = status_dict["display_content"]
+        image = status_dict.get("image")
+        text = status_dict.get("text", "Status Page")
 
-        if status_dict.get("display_content_is_image"):
-            fallback = status_dict["display_content_image_fallback"]
-
-            return f"[![{fallback}]({display_content})]({status_url})"
+        if image:
+            return f"[![{text}]({image})]({status_url})"
         else:
-            return f"[{display_content}]({status_url})"
+            return f"[{text}]({status_url})"
 
     @staticmethod
     def _create_modified_column(is_modified, source):

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -41,7 +41,7 @@ class ColumnBuilder:
         hostname = urlparse(url).hostname
         return f"[{hostname[:35] + (hostname[35:] and '...')}]({url})"
 
-    def _create_country_column(self, country_code, mirrors=None):
+    def _create_country_column(self, country_code):
         main_name, main_flag = self.get_country_name_and_flag_from_code(country_code)
         return f"{main_name} {main_flag}"
 
@@ -67,10 +67,15 @@ class ColumnBuilder:
 
     @staticmethod
     def _create_privacy_policy_column(privacy):
+        if not privacy:
+            return ""
+
         return f"[Here]({privacy})"
 
     @staticmethod
     def ddos_protection(ddos):
+        if not ddos:
+            return ""
         return f"{ddos}"
 
     @staticmethod

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -13,7 +13,6 @@ class ColumnBuilder:
             "associated_clearnet_instance": self._create_url_column,
             "country": self._create_country_column,
             "status": self._create_status_column,
-            "is_modified": self._create_modified_column,
             "privacy_policy": self._create_privacy_policy_column,
             "ddos_mitm_protection": self.ddos_protection,
             "owner": self._create_owner_column,
@@ -60,12 +59,6 @@ class ColumnBuilder:
             return f"[{text}]({status_url})"
 
     @staticmethod
-    def _create_modified_column(is_modified, source):
-        if is_modified:
-            return f"[Yes]({source})"
-        return f"No"
-
-    @staticmethod
     def _create_privacy_policy_column(privacy):
         if not privacy:
             return ""
@@ -84,14 +77,15 @@ class ColumnBuilder:
         return f"[@{author_name[-1]}]({owner})"
 
     @staticmethod
-    def _create_notes_column(notes, is_modified, source):
+    def _create_notes_column(notes, modified):
         # It is possible for both the notes and is_modified data to be falsey
-        if not notes and not is_modified:
+        if not notes and not modified:
             return ""
 
         notes_list = []
-        if is_modified:
-            notes_list.append(f" - [Modified source code]({source})")
+        if modified:
+            notes_list.append(f" - [Modified source code]({modified['source']})")
+            notes_list.append(f" - [Changes]({modified['changes']})")
         if notes:
             [notes_list.append(f" - {note}") for note in notes]
         
@@ -158,7 +152,7 @@ class MDInstanceListBuilder:
             self.builder.route("privacy_policy")(instance["privacy_policy"]),
             self.builder.route("ddos_mitm_protection")(instance["ddos_mitm_protection"]),
             self.builder.route("owner")(instance["owner"]),
-            self.builder.route("notes")(instance["notes"], instance["is_modified"], instance["source"]),
+            self.builder.route("notes")(instance["notes"], instance["modified"]),
         ]
 
     def _create_onion_row(self, instance):
@@ -169,7 +163,7 @@ class MDInstanceListBuilder:
             self.builder.route("associated_clearnet_instance")(instance["associated_clearnet_instance"]),
             self.builder.route("privacy_policy")(instance["privacy_policy"]),
             self.builder.route("owner")(instance["owner"]),
-            self.builder.route("notes")(instance["notes"], instance["is_modified"], instance["source"]),
+            self.builder.route("notes")(instance["notes"], instance["modified"]),
         ]
 
     def create(self):

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -39,7 +39,7 @@ class ColumnBuilder:
             return ""
 
         hostname = urlparse(url).hostname
-        return f"[{hostname[:35] + (hostname[35:] and '...')}]({url})"
+        return f"[{hostname[:30] + (hostname[30:] and '...')}]({url})"
 
     def _create_country_column(self, country_code):
         main_name, main_flag = self.get_country_name_and_flag_from_code(country_code)

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -88,7 +88,6 @@ class ColumnBuilder:
         
         return '<br/>'.join(notes_list)
 
-            
 
 class MDInstanceListBuilder:
     def __init__(self, instance_list_config):

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -1,92 +1,156 @@
 """Extremely quick and dirty module for creating a markdown file from the instances.yaml file"""
 from urllib.parse import urlparse
 
+import pycountry
 import yaml
 from mdutils.mdutils import MdUtils
 
 
-def create_table(table_data, instance_data):
-    rows = []
-    for field, value in instance_data.items():
-        if value is None:
-            rows.append("")
-        
-        # Use markdown links for Addresses
-        elif field in ["url", "associated_clearnet_instance"]:
-            url = urlparse(value).hostname
-            rows.append(f"[{url}]({value})")
+class ColumnBuilder:
+    def route(self, name):
+        router = {
+            "url": self._create_url_column,
+            "associated_clearnet_instance": self._create_url_column,
+            "country": self._create_country_column,
+            "status": self._create_status_column,
+            "is_modified": self._create_modified_column,
+            "privacy_policy": self._create_privacy_policy_column,
+            "ddos_mitm_protection": self.ddos_protection,
+            "owner": self._create_owner_column
+        }
 
-        elif field == "status" and value is not None:
-            if value.get("display_content_is_image"):
-                rows.append(f"[![{value['display_content_image_fallback']}]({value['display_content']})]({value['url']})")
-            else:
-                rows.append(f"[{value['display_content']}]({value['url']})")
-        
-        elif field == "country" and value:
-            rows.append(f"{value['flag']} {value['name']}")
+        return router[name]
 
-        elif field == "modified":
-            if value.get("is_modified"):
-                rows.append(f"[Yes]({value['source_url']})")
-            else:
-                rows.append("No")
+    @staticmethod
+    def _create_url_column(url):
+        if not url:
+            return ""
 
-        # We're going to use a markdown link here
-        elif field == "privacy_policy":
-            rows.append(f"[Here]({value})")
+        hostname = urlparse(url).hostname
+        return f"[{hostname}]({url})"
 
-        # Handle author name
-        elif field == "owner":
-            # Assuming github url
-            author_name = value.split("/")
-            rows.append(f"[@{author_name[-1]}]({value})")
+    @staticmethod
+    def _create_country_column(country_code):
+        country_name = pycountry.countries.get(alpha_2=country_code).name
+        # https://stackoverflow.com/a/42235254
+        flag = (lambda s, e: chr(ord(s.upper()) - 0x41 + 0x1F1E6) +
+                             chr(ord(e.upper()) - 0x41 + 0x1F1E6)
+                )(*list(country_code))
+
+        return f"{flag} {country_name}"
+
+    @staticmethod
+    def _create_status_column(status_dict):
+        if not status_dict:
+            return ""
+
+        status_url = status_dict["url"]
+        display_content = status_dict["display_content"]
+
+        if status_dict.get("display_content_is_image"):
+            fallback = status_dict["display_content_image_fallback"]
+
+            return f"[![{fallback}]({display_content})]({status_url})"
         else:
-            rows.append(value)
+            return f"[{display_content}]({status_url})"
 
-    table_data.extend(rows)
+    @staticmethod
+    def _create_modified_column(is_modified, source):
+        if is_modified:
+            return f"[Yes]({source})"
+        return f"No"
+
+    @staticmethod
+    def _create_privacy_policy_column(privacy):
+        return f"[Here]({privacy})"
+
+    @staticmethod
+    def ddos_protection(ddos):
+        return f"{ddos}"
+
+    @staticmethod
+    def _create_owner_column(owner):
+        author_name = owner.split("/")
+        return f"[@{author_name[-1]}]({owner})"
+
+
+class MDInstanceListBuilder:
+    def __init__(self, instance_list_config):
+        self.config = instance_list_config
+        self.md = MdUtils(file_name='Invidious-Instances.md')
+        self.builder = ColumnBuilder()
+
+    def _generate_heading(self):
+        self.md.new_header(level=1, title='Public Instances')
+        self.md.new_paragraph("Uptime History: [uptime.invidious.io](https://uptime.invidious.io)")
+        self.md.new_paragraph("Instances API: [api.invidious.io](api.invidious.io)")
+
+    def _create_instance_tables(self):
+        # HTTPS
+        self.md.new_header(level=1, title='Instances list')
+        rows = ["Address", "Country", "Status", "Privacy policy", "DDos Protection / MITM", "Owner", "Modified"]
+        for instance in self.config["instances"]["https"]:
+            rows.extend(self._create_http_row(instance))
+        self.md.new_table(columns=7, rows=len(self.config["instances"]["https"]) + 1, text=rows, text_align='center')
+
+        self.md.new_line()
+
+        # Onion
+        self.md.new_header(level=1, title='Onion instances list')
+        rows = ["Address", "Country", "Associated clearnet instance", "Privacy policy", "Owner", "Modified"]
+        for instance in self.config["instances"]["onion"]:
+            rows.extend(self._create_onion_row(instance))
+        self.md.new_table(columns=6, rows=len(self.config["instances"]["onion"]) + 1, text=rows, text_align='center')
+
+    def _create_prerequisite_list(self):
+        self.md.new_header(level=2, title='Prerequisites')
+        self.md.new_list(self.config["adding_instance"]["prerequisites"])
+        self.md.new_line()
+
+    def _create_direction_list(self):
+        self.md.new_header(level=2, title='Directions')
+        self.md.new_list(self.config["adding_instance"]["directions"], marked_with="1")
+        self.md.create_md_file()
+
+    def _create_http_row(self, instance):
+        return [
+            self.builder.route("url")(instance["url"]),
+            self.builder.route("country")(instance["country"]),
+            self.builder.route("status")(instance["status"]),
+            self.builder.route("privacy_policy")(instance["privacy_policy"]),
+            self.builder.route("ddos_mitm_protection")(instance["ddos_mitm_protection"]),
+            self.builder.route("owner")(instance["owner"]),
+            self.builder.route("is_modified")(instance["is_modified"], instance["source"])
+        ]
+
+    def _create_onion_row(self, instance):
+        return [
+            self.builder.route("url")(instance["url"]),
+            self.builder.route("country")(instance["country"]),
+            self.builder.route("associated_clearnet_instance")(instance["associated_clearnet_instance"]),
+            self.builder.route("privacy_policy")(instance["privacy_policy"]),
+            self.builder.route("owner")(instance["owner"]),
+            self.builder.route("is_modified")(instance["is_modified"], instance["source"])
+        ]
+
+    def create(self):
+        self._generate_heading()
+        self.md.new_line()
+
+        self._create_instance_tables()
+        self.md.new_line()
+
+        # Instance adding directions and prerequisites
+        self.md.new_header(level=1, title='Adding your instance')
+        self._create_prerequisite_list()
+        self.md.new_line()
+        self._create_direction_list()
+
+        self.md.create_md_file()
 
 
 with open("instances.yaml") as configuration_yaml:
     data = yaml.safe_load(configuration_yaml)
 
-instance_list = data["instances"]
-
-# Initial information
-md_instance_list = MdUtils(file_name='Invidious-Instances.md')
-md_instance_list.new_header(level=1, title='Public Instances')
-md_instance_list.new_paragraph("Uptime History: [uptime.invidious.io](https://uptime.invidious.io)")
-md_instance_list.new_paragraph("Instances API: [api.invidious.io](api.invidious.io)")
-
-
-# Clearnet instances
-md_instance_list.new_header(level=1, title='Instances list')
-table_data = ["Address", "Country", "Status", "Privacy policy", "DDos Protection / MITM", "Owner", "Modified"]
-for instance_data in instance_list["https"]:
-    create_table(table_data, instance_data)
-
-md_instance_list.new_line()
-md_instance_list.new_table(columns=7, rows=len(instance_list["https"]) + 1, text=table_data, text_align='center')
-
-
-# Onion instances
-md_instance_list.new_header(level=1, title='Tor onion instances list')
-table_data = ["Address", "Country", "Associated clearnet instance", "Privacy policy", "Owner", "Modified"]
-for instance_data in instance_list["onion"]:
-    create_table(table_data, instance_data) 
-
-md_instance_list.new_line()
-md_instance_list.new_table(columns=6, rows=len(instance_list["onion"]) + 1, text=table_data, text_align='center')
-
-
-# Instance adding directions and prerequisites
-md_instance_list.new_header(level=1, title='Adding your instance')
-
-# Prerequisites
-md_instance_list.new_header(level=2, title='Prerequisites')
-md_instance_list.new_list(data["adding_instance"]["prerequisites"])
-md_instance_list.new_line()
-
-# Directions
-md_instance_list.new_header(level=2, title='Directions')
-md_instance_list.new_list(data["adding_instance"]["directions"], marked_with="1")
-md_instance_list.create_md_file()
+md_builder = MDInstanceListBuilder(data)
+md_builder.create()

--- a/src/create-instance-md.py
+++ b/src/create-instance-md.py
@@ -91,7 +91,7 @@ class ColumnBuilder:
 
         notes_list = []
         if is_modified:
-            notes_list.append(f" - [Instance is running a modified source code]({source})")
+            notes_list.append(f" - [Modified source code]({source})")
         if notes:
             [notes_list.append(f" - {note}") for note in notes]
         
@@ -134,10 +134,10 @@ class MDInstanceListBuilder:
 
         # Onion
         self.md.new_header(level=1, title='Onion instances list')
-        rows = ["Address", "Country", "Associated clearnet instance", "Privacy policy", "Owner", "Notes"]
+        rows = ["Address", "Country", "Mirrors", "Associated clearnet instance", "Privacy policy", "Owner", "Notes"]
         for instance in self.config["instances"]["onion"]:
             rows.extend(self._create_onion_row(instance))
-        self.md.new_table(columns=6, rows=len(self.config["instances"]["onion"]) + 1, text=rows, text_align='center')
+        self.md.new_table(columns=7, rows=len(self.config["instances"]["onion"]) + 1, text=rows, text_align='center')
 
     def _create_prerequisite_list(self):
         self.md.new_header(level=2, title='Prerequisites')
@@ -165,6 +165,7 @@ class MDInstanceListBuilder:
         return [
             self.builder.route("url")(instance["url"]),
             self.builder.route("country")(instance["country"]),
+            self.builder.route("mirrors")(instance["mirrors"]),
             self.builder.route("associated_clearnet_instance")(instance["associated_clearnet_instance"]),
             self.builder.route("privacy_policy")(instance["privacy_policy"]),
             self.builder.route("owner")(instance["owner"]),

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 mdutils==1.3.0
+pycountry==20.7.3
 PyYAML==5.4.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-mdutils==1.3.0
+mdutils==1.3.1
 pycountry==20.7.3
 PyYAML==5.4.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,2 @@
+mdutils==1.3.0
+PyYAML==5.4.1


### PR DESCRIPTION
This is an alternative take on #74 that automates everything. 

Preview: https://github.com/syeopite/documentation/blob/alt-instance-list/Invidious-Instances.md

The Instance list is now defined in `instances.yaml`. When a PR is made that edits that file, GH actions would run and automatically generate the markdown version of the list through a python script. 

The data and design (markdown result) from this PR is mostly taken from #74 as well