### PR TITLE
Remove invidious.exonip.de because it is broken

### DIFF
--- a/Invidious-Instances.md
+++ b/Invidious-Instances.md
@@ -42,8 +42,6 @@ To be in this list, instances must have been updated in the last month. An insta
 
 * [invidious.silkky.cloud](https://invidious.silkky.cloud) 🇫🇮 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m787784614-79d1acc4b425d1ed813fc793)](https://status.silkky.cloud/787784614)
 
-* [invidious.exonip.de](https://invidious.exonip.de) 🇩🇪 [Status Page](https://status.exonip.de/)
-
 * [inv.riverside.rocks](https://inv.riverside.rocks) 🇺🇸
 
 * [invidious.blamefran.net](https://invidious.blamefran.net) 🇺🇸


### PR DESCRIPTION
4 issues about the instance were opened in the last few days:
- https://github.com/iv-org/invidious/issues/2163
- https://github.com/iv-org/invidious/issues/2162
- https://github.com/iv-org/invidious/issues/2161
- https://github.com/iv-org/invidious/issues/2160

I think we should remove it for the moment until the errors are fixed. For example, I just tested, and I can't register on the instance.

@Exonip Could fix the issues on your instance?