### PR TITLE
create crystal symlink instead of copy

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -142,7 +142,7 @@ cd ~/Downloads
 wget https://github.com/crystal-lang/crystal/releases/download/1.0.0/crystal-1.0.0-1-linux-x86_64.tar.gz
 cd /opt
 sudo tar -xzf ~/Downloads/crystal-1.0.0-1-linux-x86_64.tar.gz
-sudo cp /opt/crystal-1.0.0-1/bin/{crystal,shards} /usr/local/bin/
+sudo ln -s /opt/crystal-1.0.0-1/bin/{crystal,shards} /usr/local/bin/
 ```
 
 #### Install the dependencies


### PR DESCRIPTION
When installing the tarball and copying crystal to /usr/local/bin:
`$ crystal`
`/usr/local/bin/crystal: 99: /usr/local/bin/crystal: /usr/local/bin/../lib/crystal/bin/crystal: not found`
`/usr/local/bin/crystal: 103: exec: /usr/local/bin/../lib/crystal/bin/crystal: not found`

Following the instructions from https://crystal-lang.org/install/from_targz/ does work.