### PR TITLE
Instances rules modifications

### DIFF
--- a/Invidious-Instances.md
+++ b/Invidious-Instances.md
@@ -75,6 +75,6 @@ dateCreated: 2021-05-23T16:58:48.431Z
     - MUST respect the AGPL by publishing their source code and stating their changes **before** they are be added to the list
     - MUST publish any later modification in a timely manner
     - MUST contain a link to both the modified and original source code of Invidious in the footer.
-12. Instances MUST NOT serve ads (sponsorship links in banner are considered ads) NOR promote products.
+12. Instances MUST NOT serve ads (sponsorship links in the banner are considered ads) NOR promote products.
 
 **NOTE:** We reserve the right to decline any instance from being added to the list, and to remove or ban any instance that repeatedly breaks the aforementioned rules.


### PR DESCRIPTION
Instances rules modification proposal as a follow-up of the discussions from #148 and #149.

The idea is to provide an ad/tracker free official list, and to clarify some other rules.


notes: it could be a good idea to also remove the 1st rule and transform it to a more meaningful note/warning saying that the newly added instances will be on a probatory period of 1 months (should be more imho) before they can be added to the official list, so we can ensure that the owner is able to keep it updated at least once a month.