### PR TITLE
Add healthcheck for docker-compose + autoheal for auto restart

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -88,8 +88,20 @@ services:
         https_only: false
         domain: 
       # external_port:
+    healthcheck:
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 2
     depends_on:
       - postgres
+  autoheal:
+    restart: always
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   postgresdata:


### PR DESCRIPTION
Inquire http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw every 30 seconds, mark Unhealthy when an error returns.
Restart the container if the container is in Unhealthy condition using autoheal.
https://matrix.to/#/!GMIiONJMKtiqFzSxwj:snopyta.org/$16345613910sEVSJ:hub.ne.kr?via=snopyta.org&via=matrix.org&via=libera.chat