### PR TITLE
Enhance the production compose file

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -76,7 +76,7 @@ services:
       - invidious-db
 
   invidious-db:
-    image: postgres:14-alpine
+    image: docker.io/library/postgres:14-alpine
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/Installation.md
+++ b/Installation.md
@@ -56,16 +56,17 @@ services:
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
       INVIDIOUS_CONFIG: |
-        check_tables: true
         db:
           dbname: invidious
           user: kemal
           password: kemal
           host: invidious-postgres
           port: 5432
-        # https_only: false
-        # domain:
+        check_tables: true
         # external_port:
+        # domain:
+        # https_only: false
+        # statistics_enabled: false
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
       interval: 30s

--- a/Installation.md
+++ b/Installation.md
@@ -52,19 +52,19 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
+      INVIDIOUS_CONFIG: |
       # Please read the following file for a comprehensive list of all available
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
-      INVIDIOUS_CONFIG: |
         channel_threads: 1
         check_tables: true
         feed_threads: 1
         db:
+          dbname: invidious
           user: kemal
           password: kemal
-          host: postgres
+          host: invidious-postgres
           port: 5432
-          dbname: invidious
         full_refresh: false
         https_only: false
         domain:
@@ -75,9 +75,9 @@ services:
       timeout: 5s
       retries: 2
     depends_on:
-      - postgres
+      - invidious-postgres
 
-  postgres:
+  invidious-postgres:
     image: postgres:14
     restart: unless-stopped
     volumes:

--- a/Installation.md
+++ b/Installation.md
@@ -52,10 +52,10 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
-      INVIDIOUS_CONFIG: |
       # Please read the following file for a comprehensive list of all available
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
+      INVIDIOUS_CONFIG: |
         check_tables: true
         db:
           dbname: invidious

--- a/Installation.md
+++ b/Installation.md
@@ -56,19 +56,16 @@ services:
       # Please read the following file for a comprehensive list of all available
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
-        channel_threads: 1
         check_tables: true
-        feed_threads: 1
         db:
           dbname: invidious
           user: kemal
           password: kemal
           host: invidious-postgres
           port: 5432
-        full_refresh: false
-        https_only: false
-        domain:
-      # external_port:
+        # https_only: false
+        # domain:
+        # external_port:
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
       interval: 30s

--- a/Installation.md
+++ b/Installation.md
@@ -77,7 +77,7 @@ services:
       - invidious-db
 
   invidious-db:
-    image: docker.io/library/postgres:14-alpine
+    image: docker.io/library/postgres:14
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/Installation.md
+++ b/Installation.md
@@ -43,13 +43,43 @@ cd invidious
 Edit the docker-compose.yml with this content:
 
 ```docker
-version: "2.4"
+version: "3"
 services:
+
+  invidious:
+    image: quay.io/invidious/invidious:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      # Please read the following file for a comprehensive list of all available
+      # configuration options and their associated syntax:
+      # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
+      INVIDIOUS_CONFIG: |
+        channel_threads: 1
+        check_tables: true
+        feed_threads: 1
+        db:
+          user: kemal
+          password: kemal
+          host: postgres
+          port: 5432
+          dbname: invidious
+        full_refresh: false
+        https_only: false
+        domain:
+      # external_port:
+    healthcheck:
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 2
+    depends_on:
+      - postgres
+
   postgres:
-    image: postgres:10
-    restart: always
-    networks:
-      - invidious
+    image: postgres:14
+    restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data
       - ./config/sql:/config/sql
@@ -60,53 +90,9 @@ services:
       POSTGRES_PASSWORD: kemal
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
-  invidious:
-    image: quay.io/invidious/invidious:latest
-    restart: always
-    networks:
-      - invidious
-    mem_limit: 1024M
-    cpus: 0.5
-    ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      INVIDIOUS_CONFIG: | 
-      # Please read the following file for a comprehensive list of all available
-      # configuration options and their associated syntax:
-      # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
-        channel_threads: 1
-        check_tables: true
-        feed_threads: 1
-        db:
-          dbname: invidious
-          user: kemal
-          password: kemal
-          host: postgres
-          port: 5432
-        full_refresh: false
-        https_only: false
-        domain: 
-      # external_port:
-    healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
-      interval: 30s
-      timeout: 5s
-      retries: 2
-    depends_on:
-      - postgres
-  autoheal:
-    restart: always
-    image: willfarrell/autoheal
-    environment:
-      - AUTOHEAL_CONTAINER_LABEL=all
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   postgresdata:
-
-networks:
-  invidious:
 ```
 
 Note: This compose is made for a true "production" setup, where Invidious is behind a reverse proxy. If you prefer to directly access Invidious, replace `127.0.0.1:3000:3000` with `3000:3000` under the `ports:` section.

--- a/Installation.md
+++ b/Installation.md
@@ -75,7 +75,7 @@ services:
       - invidious-postgres
 
   invidious-postgres:
-    image: postgres:14
+    image: postgres:14-alpine
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/Installation.md
+++ b/Installation.md
@@ -47,7 +47,6 @@ version: "3"
 services:
 
   invidious:
-    container_name: invidious
     image: quay.io/invidious/invidious:latest
     restart: unless-stopped
     ports:
@@ -77,7 +76,6 @@ services:
       - invidious-db
 
   invidious-db:
-    container_name: invidious-db
     image: postgres:14-alpine
     restart: unless-stopped
     volumes:

--- a/Installation.md
+++ b/Installation.md
@@ -47,6 +47,7 @@ version: "3"
 services:
 
   invidious:
+    container_name: invidious
     image: quay.io/invidious/invidious:latest
     restart: unless-stopped
     ports:
@@ -60,7 +61,7 @@ services:
           dbname: invidious
           user: kemal
           password: kemal
-          host: invidious-postgres
+          host: invidious-db
           port: 5432
         check_tables: true
         # external_port:
@@ -73,9 +74,10 @@ services:
       timeout: 5s
       retries: 2
     depends_on:
-      - invidious-postgres
+      - invidious-db
 
-  invidious-postgres:
+  invidious-db:
+    container_name: invidious-db
     image: postgres:14-alpine
     restart: unless-stopped
     volumes:

--- a/Installation.md
+++ b/Installation.md
@@ -48,6 +48,7 @@ services:
 
   invidious:
     image: quay.io/invidious/invidious:latest
+    # image: quay.io/invidious/invidious:latest-arm64 # ARM64/AArch64 devices
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"


### PR DESCRIPTION
Follow up to https://github.com/iv-org/documentation/pull/160#issuecomment-1039778281

Related to https://github.com/iv-org/invidious/pull/2917 (wait for both to be ready - so that we can merge them at the same time)


Massively enhance the production compose:

- Make the production and development compose use the same (sane and clean) bases
- Change the restart policy for `unless-stopped` since `always` is bad practice
- Remove the network (that's completely useless)
- Remove the resources limiters (that's not really useful, and users should only use it if they need to)
- Remove the `willfarrell/autoheal` container: we can't vouch for it's usefulness, and its security (it has access to the docker socket, which is a massive security risk)
- Bump the postgres version to 14 since it's the latest and 10 [EOL in 8 months](https://www.postgresql.org/support/versioning/) ~~and move to an Alpine-based Postgres image~~
- Layout change (service then DB)
- ~~Enforce a container_name~~ **Edit:** https://github.com/iv-org/documentation/pull/200#discussion_r811676660

It has been tested, and it's working