### PR TITLE
Prefer shards install production

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -184,7 +184,8 @@ exit
 ```bash
 su - invidious
 cd invidious
-shards update && shards install && crystal build src/invidious.cr --release
+shards install --production
+crystal build src/invidious.cr --release
 exit
 ```
 


### PR DESCRIPTION
This ensures that the exact dependencies versions from shard.lock are used.
See: https://github.com/iv-org/invidious/issues/2918