### PR TITLE
Remove instance invidio.xamh.de

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -22,8 +22,6 @@
 
 * [invidious.osi.kr](https://invidious.osi.kr) 🇳🇱 [Status Page](https://status.osbusiness.net/report/uptime/6e47474f3737993d8a3fde06f33dc128/)
 
-* [invidio.xamh.de](https://invidio.xamh.de) 🇩🇪 ![Uptime Robot status](https://img.shields.io/uptimerobot/status/m788804183-a33a0af7fb40e3bafa617cd8)
-
 * [youtube.076.ne.jp](https://youtube.076.ne.jp) 🇯🇵 - Source code/changes: https://git.076.ne.jp/TechnicalSuwako/invidious-mod
 
 * [yt.artemislena.eu](https://yt.artemislena.eu) 🇩🇪


### PR DESCRIPTION
Since I need to rebuild the database therefore its down( it will probably be today and a few days since I don't have much time) and it makes no sense to have a broken instance on that list.