### PR TITLE
delist invidious.privacy.gd

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -30,8 +30,6 @@
 
 * [invidious.flokinet.to](https://invidious.flokinet.to) 🇷🇴
 
-* [invidious.privacy.gd](https://invidious.privacy.gd) 🇺🇸
-
 * [invidious.weblibre.org](https://invidious.weblibre.org) 🇨🇱
 
 * [invidious.esmailelbob.xyz](https://invidious.esmailelbob.xyz) 🇨🇦
@@ -58,8 +56,6 @@
 * [osbivz6guyeahrwp2lnwyjk2xos342h4ocsxyqrlaopqjuhwn2djiiyd.onion](http://osbivz6guyeahrwp2lnwyjk2xos342h4ocsxyqrlaopqjuhwn2djiiyd.onion) 🇳🇱 (Onion of invidious.hub.ne.kr)
 
 *  [u2cvlit75owumwpy4dj2hsmvkq7nvrclkpht7xgyye2pyoxhpmclkrad.onion](http://u2cvlit75owumwpy4dj2hsmvkq7nvrclkpht7xgyye2pyoxhpmclkrad.onion) 🇺🇸 (Onion of inv.riverside.rocks)
-
-* [2rorw2w54tr7jkasn53l5swbjnbvz3ubebhswscnc54yac6gmkxaeeqd.onion](http://2rorw2w54tr7jkasn53l5swbjnbvz3ubebhswscnc54yac6gmkxaeeqd.onion) 🇺🇸 (Onion of invidious.privacy.gd)
 
 * [euxxcnhsynwmfidvhjf6uzptsmh4dipkmgdmcmxxuo7tunp3ad2jrwyd.onion](http://euxxcnhsynwmfidvhjf6uzptsmh4dipkmgdmcmxxuo7tunp3ad2jrwyd.onion/) 🇩🇪 (Onion of invidious.sethforprivacy.com)
 


### PR DESCRIPTION
instance breaks rule 4 'Instances MUST have an uptime of at least 90% (according to uptime.invidious.io).'
should also be delisted because the instance is down for over a month

https://stats.uptimerobot.com/89VnzSKAn/790590336

in theory the instance could reach 90% at the end of the year if it is going live now but i assume doesnt matter at this point