### PR TITLE
Improve navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,33 @@ site_description: >-
   The official Invidious documentation
 copyright: CC0 1.0 Universal (CC0 1.0)
 
+nav:
+  - Home: 'index.md'
+  - 'General':
+    - 'instances.md'
+    - 'export-youtube-subscriptions.md'
+    - 'preferences.md'
+    - 'applications.md'
+    - 'search-filters.md'
+    - 'url-parameters.md'
+    - 'proxy-videos.md'
+    - 'geoblocking.md'
+    - 'umatrix.md'
+    - 'known-exception.md'
+  - 'faq.md'
+  - 'For Administrators':
+    - 'installation.md'
+    - 'configuration.md'
+    - 'apache2.md'
+    - 'nginx.md'
+    - 'db-maintenance.md'
+    - 'captcha-bug.md'
+    - 'anti-captcha.md'
+    - 'takedown.md'
+  - 'For Developers':
+    - 'api.md'
+    - 'authenticated-endpoints.md'
+
 theme:
   name: material
   font: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,11 @@
 site_name: Invidious Documentation
 site_url: https://docs.invidious.io/
+repo_url: https://github.com/iv-org/documentation
 site_author: The Invidious project.
 site_description: >-
   The official Invidious documentation
+copyright: CC0 1.0 Universal (CC0 1.0)
+
 theme:
   name: material
   font: false
@@ -14,6 +17,7 @@ theme:
     - navigation.tracking # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-tracking
     - navigation.expand # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-expansion
     - navigation.top # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#back-to-top-button
+
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
     - 'geoblocking.md'
     - 'umatrix.md'
     - 'known-exception.md'
-  - 'faq.md'
+    - 'faq.md'
   - 'For Administrators':
     - 'installation.md'
     - 'configuration.md'


### PR DESCRIPTION
This PR improves the navigation on the doc in various ways:
- Add structure to the main menu to improve the navigation and readability for users.
- Add the repo_url to mkdocs config. This add a pen icon on each documentation page which redirects to the file in the Github repo.
- Enable the Github logo by adding the repo_url configuration.
- Add a copyright notice to inform that the website content is under CC0 1.0 Universal (CC0 1.0), the license used by this repository.