### PR TITLE
Add Caddy web server reverse proxy documentation

### DIFF
--- a/docs/caddy.md
+++ b/docs/caddy.md
@@ -1,0 +1,14 @@
+# Caddy reverse proxy
+
+This is a very basic config, assuming that you're using Caddy to manage SSL certificates for you.
+Any log is disabled by default. Do not forget to replace `server_name` with your domain.
+
+```
+https://<server_name> {
+  reverse_proxy localhost:3000
+
+  log {
+      output discard
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@
 - [Configuration](./configuration.md)
 - [Apache2 Virtual Host with Reverse Proxy](./apache2.md)
 - [Nginx Reverse Proxy Configuration](./nginx.md)
+- [Caddy Reverse Proxy Configuration](./caddy.md)
 - [Database Information and Maintenance](./db-maintenance.md)
 - [Issues with CAPTCHA](./captcha-bug.md)
 - [How to setup Anti-Captcha](./anti-captcha.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - 'configuration.md'
     - 'apache2.md'
     - 'nginx.md'
+    - 'caddy.md'
     - 'db-maintenance.md'
     - 'captcha-bug.md'
     - 'anti-captcha.md'


### PR DESCRIPTION
Hey!

I'm using [Caddy web server](https://caddyserver.com/) as a reverse proxy for my Invidious instance, so I wrote a basic docs page for it. Tried to mimic all the content from Apache and Nginx docs :)

Have a good one!