### PR TITLE
Install steps: Prefer `make` over crystal commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,8 +165,7 @@ exit
 ```bash
 su - invidious
 cd invidious
-shards install --production
-crystal build src/invidious.cr --release
+make
 cp config/config.example.yml config/config.yml 
 # Configure config/config.yml how you want
 exit


### PR DESCRIPTION
The makefile allows us to propose sane defaults without having to change the documentation all the time.

This is a follow-up to iv-org/invidious#3367 and iv-org/invidious#3376