### PR TITLE
 Unify log rotation settings for both docker and manual install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,6 +68,10 @@ services:
       interval: 30s
       timeout: 5s
       retries: 2
+    logging:
+      options:
+        max-size: "1G"
+        max-file: "4"
     depends_on:
       - invidious-db
 


### PR DESCRIPTION
Hey!

After running a public instance for ~2 months, I've noticed that the default docker-based installation doesn't have any limit for the log file size. Invidious logs quite a lot by default, it has generated a few logfiles larger than 10GB on my server.

This MR unifies the logging limits in docker-based installation and the logrotate configuration described in the `Logrotate configuration` documentation section:
- single logfile size limit set to `1G`
- max number of saved log files set to `4`

The configuration was tested on my server and I confirm that its rotating the logs correctly :)