### PR TITLE
Installation: Remove outdated warning about `$POSTGRES_USER`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,8 +95,6 @@ volumes:
 
 Note: This compose is made for a true "production" setup, where Invidious is behind a reverse proxy. If you prefer to directly access Invidious, replace `127.0.0.1:3000:3000` with `3000:3000` under the `ports:` section.
 
-**The environment variable `POSTGRES_USER` cannot be changed. The SQL config files that run the initial database migrations are hard-coded with the username `kemal`.**
-
 
 ### Docker-compose method (development)
 


### PR DESCRIPTION
The statements are no longer true since the database migrations now reference `current_user` instead of `kemal`.

See also [this comment](https://github.com/iv-org/invidious/pull/1678#discussion_r559189558) pertaining to [this commit](https://github.com/iv-org/invidious/commit/ffa9e5dfab7a1d7ea84d88007107f9f40295c50a).