### PR TITLE
Rename inv.odyssey346.dev instance

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -34,7 +34,7 @@
 
 * [invidious.slipfox.xyz](https://invidious.slipfox.xyz) 🇺🇸
 
-* [inv.odyssey346.dev](https://inv.odyssey346.dev) 🇫🇷
+* [inv.pistasjis.net](https://inv.pistasjis.net) 🇫🇷
 
 * [invidious.baczek.me](https://invidious.baczek.me) 🇵🇱
 


### PR DESCRIPTION
I have moved the domain of the ``inv.odyssey346.dev`` Invidious instance to ``inv.pistasjis.net``, and I was told to create a PR for this. So, this is that PR.