### PR TITLE
chore: update applications list

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -1,32 +1,43 @@
 # Applications
 
-### Browser extensions for Invidious
-- [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect): Redirects YouTube to Invidious, Twitter to Nitter, and Instagram to Bibliogram. [Source](https://github.com/SimonBrazell/privacy-redirect) / [Firefox](https://addons.mozilla.org/addon/privacy-redirect) / [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb)
-- [Alter](https://addons.mozilla.org/addon/alter): Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter)
-- [SponsorBlock](https://github.com/ajayyy/SponsorBlock): A crowd-sourced extension to skip sponsorships. Support invidious instances if enabled in the options. [Source](https://github.com/ajayyy/SponsorBlock) / [Firefox](https://addons.mozilla.org/addon/sponsorblock) / [Chrome](https://chrome.google.com/webstore/detail/mnjggcdmjocbbbhaepdhchncahnbgone)
-- [Invidition](https://addons.mozilla.org/addon/invidition): Firefox extension that redirects YouTube links and embeds to their Invidious counterpart without any call to YouTube. [Source](https://codeberg.org/Booteille/Invidition)  (**deprecated**).
-- [Alternate Tube Redirector](https://gitlab.com/2vek/alternate-tube-redirector): Extension to automatically open YouTube Videos on alternate sites like Invidious or Hooktube. [Source](https://gitlab.com/2vek/alternate-tube-redirector)
-- [Invidious Copy URL](https://github.com/recette-lemon/invidious-copy-url): Adds context menu options on Invidious to copy shortened YouTube URL at current time or not (Requires using developer mode in Chrome or a developer version of Firefox).
-- [View on Invidious](https://omar.yt/722e5c15832840fe1ae8830b7c590254b9e0a45c/invidious-bookmarklet.html): View page on Invidious (bookmarklet).
-- [Inviduration](https://addons.mozilla.org/addon/inviduration): Firefox extension that shows total duration of playlists on Invidious. [Source](https://github.com/rsapkf/inviduration) / [Firefox](https://addons.mozilla.org/addon/inviduration)
-- [Redirector](https://github.com/einaregilsson/Redirector): Extension for Firefox and Chromium that can manually be configured to process Inidious Redirects. For details, see the [setup page](./redirector-setup.md) to use it with Invidious.
+Lists of third-party projects that use or support Invidious.
+
+### Browser Extensions
+
+| Name | Description | Links |
+|---|---|---|
+| [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) | Redirects YouTube to Invidious, Twitter to Nitter, and Instagram to Bibliogram. | [Source](https://github.com/SimonBrazell/privacy-redirect) / [Firefox](https://addons.mozilla.org/addon/privacy-redirect) / [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb) |
+| [Alter](https://addons.mozilla.org/addon/alter) | Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. | [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter) |
+| [SponsorBlock](https://github.com/ajayyy/SponsorBlock) | A crowd-sourced extension to skip sponsorships. Support invidious instances if enabled in the options. | [Source](https://github.com/ajayyy/SponsorBlock) / [Firefox](https://addons.mozilla.org/addon/sponsorblock) / [Chrome](https://chrome.google.com/webstore/detail/mnjggcdmjocbbbhaepdhchncahnbgone) |
+| [Invidious Copy URL](https://github.com/recette-lemon/invidious-copy-url) | Adds context menu options on Invidious to copy shortened YouTube URL at current time or not (Requires using developer mode in Chrome or a developer version of Firefox). | |
+| [View on Invidious](https://omar.yt/722e5c15832840fe1ae8830b7c590254b9e0a45c/invidious-bookmarklet.html) | View page on Invidious (bookmarklet). | |
+| [Inviduration](https://addons.mozilla.org/addon/inviduration) | Firefox extension that shows total duration of playlists on Invidious. | [Source](https://github.com/rsapkf/inviduration) / [Firefox](https://addons.mozilla.org/addon/inviduration) |
+| [Redirector](https://github.com/einaregilsson/Redirector) | Extension for Firefox and Chromium that can manually be configured to process Invidious Redirects. For details, see the [setup page](./redirector-setup.md) to use it with Invidious. |
 
 ### Userscripts for Invidious.
-- [Invidious Redirect](https://greasyfork.org/en/scripts/370461-invidious-redirect): Redirects YouTube URLs to a deprecated instance, but can be edited to redirect to a different instance.
-- [YouTube to Invidious](https://greasyfork.org/en/scripts/375264-youtube-to-invidious): Scans current page for YouTube embeds and replace with invidio.us. (Can be edited to use any preffered instance)
-- [No-Youtube](https://github.com/mperez01/no-youtube): Userscript to replace youtube links to invidio.us. Can be edited to redirect to a preffered instance.
-- [FYTE](https://greasyfork.org/en/scripts/9252-fyte-fast-youtube-embedded-player): Replace all YouTube embeds on a page with the video's thumbnail. Click on the thumbnail to play the video. Invidious is supported in the Options panel (redirects to invidio.us by default, can be edited).
-- [Privacy Redirector](https://github.com/dybdeskarphet/privacy-redirector): Userscript to automatically redirect to different private frontents, including Invidious. Can be configured to redirect to specific instances of the user's choice.
-- [Simple Sponsor Skipper](https://codeberg.org/mthsk/userscripts/src/branch/master/simple-sponsor-skipper): Userscript based on Sponsorblock that is pre-configured to work with multiple Invidious instances, but can be easily altered to use any instance desired by the user.
-- [Invidious Preferences Userscript](https://github.com/MintMain21/Invidious-Preferences-Userscript) Userscript for enforcing preferences accross multiple instances, through URL Parameters, and without using browser cookies. Works in tandum with Privacy Redirector and Simple Sponsor Skipper. See [here](https://docs.invidious.io/url-parameters/) for more information about URL Parameters. 
 
-### Extensions that integrate Invidious into other programs and apps
-- [UntrackMe](https://f-droid.org/en/packages/app.fedilab.nitterizeme): Android app to rewrite YouTube links to Invidious. Can optionally play videos in the app as well.
-- [iPhone Redirector Shortcut](https://www.icloud.com/shortcuts/6bbf26d989cf4d07a5fe1626efbc0950): Automatically open YouTube videos in Invidious (iPhone shortcut).
-- [FreshRSS Extension](https://github.com/tmiland/freshrss-invidious): A FreshRSS extension to directly embed videos from Invidious channel feeds.
-- [Kodi add-on](https://github.com/TheAssassin/kodi-invidious-plugin): Watch YouTube videos in the Kodi media center, using the Invidious API. Privacy-friendly alternative to the YouTube API add-on.
-- [Another Kodi add-on](https://github.com/lekma/plugin.video.invidious): Seems to have been more recently updated than the above.
-- [Playlet](https://github.com/iBicha/playlet): A Roku TV Youtube app that uses Invidious as a backend. [Roku Store](https://my.roku.com/account/add?channel=PLAYLET)
+| Name | Description |
+|---|---|
+| [Invidious Redirect](https://greasyfork.org/en/scripts/370461-invidious-redirect) | Redirects YouTube URLs to a deprecated instance, but can be edited to redirect to a different instance. |
+| [YouTube to Invidious](https://greasyfork.org/en/scripts/375264-youtube-to-invidious) | Scans current page for YouTube embeds and replace with invidio.us. (Can be edited to use any preferred instance) |
+| [No-Youtube](https://github.com/mperez01/no-youtube) | Userscript to replace YouTube links to invidio.us. Can be edited to redirect to a preferred instance.
+| [FYTE](https://greasyfork.org/en/scripts/9252-fyte-fast-youtube-embedded-player) | Replace all YouTube embeds on a page with the video's thumbnail. Click on the thumbnail to play the video. Invidious is supported in the Options panel (redirects to invidio.us by default, can be edited). |
+| [Privacy Redirector](https://github.com/dybdeskarphet/privacy-redirector) | Userscript to automatically redirect to different private frontends, including Invidious. Can be configured to redirect to specific instances of the user's choice. |
+| [Simple Sponsor Skipper](https://codeberg.org/mthsk/userscripts/src/branch/master/simple-sponsor-skipper) | Userscript based on SponsorBlock that is pre-configured to work with multiple Invidious instances, but can be easily altered to use any instance desired by the user. |
+| [Invidious Preferences Userscript](https://github.com/MintMain21/Invidious-Preferences-Userscript) | Userscript for enforcing preferences across multiple instances, through URL Parameters, and without using browser cookies. Works in tandem with Privacy Redirector and Simple Sponsor Skipper. See [here](https://docs.invidious.io/url-parameters/) for more information about URL Parameters. |
 
-### Utilities for Invidious
-- [Invidious-Updater (And Installer)](https://github.com/tmiland/Invidious-Updater): Automatic install and update script for Invidious.
+### Extensions that Integrate Invidious into other Apps
+
+| Name | Description | Links |
+|---|---|---|
+| [UntrackMe](https://f-droid.org/en/packages/app.fedilab.nitterizeme) | Android app to rewrite YouTube links to Invidious. Can optionally play videos in the app as well. | |
+| [iPhone Redirector Shortcut](https://www.icloud.com/shortcuts/6bbf26d989cf4d07a5fe1626efbc0950) | Automatically open YouTube videos in Invidious (iPhone shortcut). | |
+| [FreshRSS Extension](https://github.com/tmiland/freshrss-invidious) | A FreshRSS extension to directly embed videos from Invidious channel feeds. | |
+| [Kodi add-on](https://github.com/lekma/plugin.video.invidious) | Watch YouTube videos in the Kodi media center, using the Invidious API. Privacy-friendly alternative to the YouTube API add-on. | |
+| [Playlet](https://github.com/iBicha/playlet) | A Roku TV YouTube app that uses Invidious as a backend. | [Roku Store](https://channelstore.roku.com/en-ca/details/840aec36f51bfe6d96cf6db9055a372a/playlet) |
+
+### Utilities
+
+| Name | Description |
+|---|---|
+| [Invidious-Updater (And Installer)](https://github.com/tmiland/Invidious-Updater) | Automatic install and update script for Invidious. |


### PR DESCRIPTION
### Chores

* Converts all lists in this page to tables.
* Fixes various typos found in the document.

---

### Changes to the actual list

* Replaces Roku link for Playlet with one that doesn't require authentication to read.
* Removes Invidition, as the add-on's page literally instructs users to just use Privacy Redirect instead.
* Removes Alternate Tube Redirector, as this has not been maintained in years and was removed from the Mozilla add-on.
* Removes Kodi add-on (by TheAssassin) as this is no longer maintained, repo was archived, and search is broken.
* Renames Another Kodi add-on (by lekma) to just Kodi add-on as this is actively maintained and is far ahead in terms of features compared to the previous one.

---

Preview here:
https://github.com/SethFalco/documentation-1/blob/chore-apps/docs/applications.md

**Ignore LibRedirect in the screenshots, I've removed that in the PR. [[reference]](https://github.com/iv-org/invidious/pull/3901)**

![image](https://github.com/iv-org/documentation/assets/22801583/02bb085a-0e71-47d6-80cc-51750ccf3442)

![image](https://github.com/iv-org/documentation/assets/22801583/69de4b02-d43a-4527-9905-a8a02e7613f9)
