### PR TITLE
Fix admonition on 'Database maintenance' page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,3 +81,4 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.details # https://facelessuser.github.io/pymdown-extensions/extensions/details/
+  - admonition


### PR DESCRIPTION
This MR adds mkdocs' [`admonitions`](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) extension, which fixes the syntax used in the 'Database maintenance' page.

Current:

![image](https://github.com/iv-org/documentation/assets/19196352/334a18ae-e51b-4588-b712-1a64cad290ac)

After fix:

![image](https://github.com/iv-org/documentation/assets/19196352/17ef41bc-54ca-4613-b98c-37ac6d759923)
