### PR TITLE
applications.md - Various changes and re-order by oldest to newest (for now)

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -6,14 +6,14 @@ Lists of third-party projects that use or support Invidious.
 | Name | Description | Links |
 | --- | --- | --- |
 | [FreeTube](https://github.com/FreeTubeApp/FreeTube) | A desktop libre software YouTube app for privacy. | |
-| [Playlet](https://github.com/iBicha/playlet) | A Roku TV YouTube app that uses Invidious as a backend. | [Roku Store](https://channelstore.roku.com/en-ca/details/840aec36f51bfe6d96cf6db9055a372a/playlet) |
 | [Clipious](https://github.com/lamarios/clipious) | Unofficial Invidious client for Android | |
-| [Yattee](https://github.com/yattee/yattee) | Alternative YouTube frontend for iPhone, iPad, Mac and Apple TV. | |
+| [Yattee](https://github.com/yattee/yattee) | Alternative YouTube frontend for iPhone, iPad, Mac and Apple TV. | [App Store](https://apps.apple.com/app/yattee/id1595136629) |
 | [CloudTube](https://sr.ht/~cadence/tube/) | A JavaScript-rich alternate online YouTube player. | |
 | [HoloPlay](https://github.com/stephane-r/holoplay-pwa)| Progressive Web App for music connecting on Invidious API's with search, playlists and favorites. | |
-| [GTK+ Pipe Viewer](https://github.com/trizen/pipe-viewer) | YouTube client for Linux. | |
 | [PlasmaTube](https://invent.kde.org/multimedia/plasmatube/) | YouTube client for Linux. | [KDE Applications](https://apps.kde.org/plasmatube/) |
-| [WatchTube](https://github.com/WatchTubeTeam/) | Powerful YouTube client for Apple Watch. | |
+| [GTK+ Pipe Viewer](https://github.com/trizen/pipe-viewer) | YouTube client for Linux. | |
+| [WatchTube](https://github.com/WatchTubeTeam/) | Powerful YouTube client for Apple Watch. | [App Store](https://apps.apple.com/app/watchtube/id1599884909) |
+| [Playlet](https://github.com/iBicha/playlet) | A Roku TV YouTube app that uses Invidious as a backend. | [Roku Store](https://channelstore.roku.com/en-ca/details/840aec36f51bfe6d96cf6db9055a372a/playlet) |
 | [TubiTui](https://codeberg.org/777/TubiTui) | A lightweight, libre, TUI-based YouTube client. For desktop. | |
 | [Ytfzf](https://github.com/pystardust/ytfzf) | A posix script to find and watch youtube videos from the terminal. (Without API). | |
 
@@ -22,12 +22,12 @@ Lists of third-party projects that use or support Invidious.
 | Name | Description | Links |
 |---|---|---|
 | [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) | Redirects YouTube to Invidious, Twitter to Nitter, and Instagram to Bibliogram. | [Source](https://github.com/SimonBrazell/privacy-redirect) / [Firefox](https://addons.mozilla.org/addon/privacy-redirect) / [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb) |
-| [Alter](https://addons.mozilla.org/addon/alter) | Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. | [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter) |
+| [Alter](https://github.com/w3bdev1/alter) | Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. | [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter) |
+| [Redirector](https://github.com/einaregilsson/Redirector) | Extension for Firefox and Chromium that can manually be configured to process Invidious Redirects. For details, see the [setup page](./redirector.md) to use it with Invidious. | [Source](https://github.com/einaregilsson/Redirector) / [Firefox](https://addons.mozilla.org/addon/redirector) / [Chrome](https://chrome.google.com/webstore/detail/redirector/ocgpenflpmgnfapjedencafcfakcekcd) |
+| [View on Invidious](https://omar.yt/722e5c15832840fe1ae8830b7c590254b9e0a45c/invidious-bookmarklet.html) | View page on Invidious (bookmarklet). | |
 | [SponsorBlock](https://github.com/ajayyy/SponsorBlock) | A crowd-sourced extension to skip sponsorships. Support invidious instances if enabled in the options. | [Source](https://github.com/ajayyy/SponsorBlock) / [Firefox](https://addons.mozilla.org/addon/sponsorblock) / [Chrome](https://chrome.google.com/webstore/detail/mnjggcdmjocbbbhaepdhchncahnbgone) |
 | [Invidious Copy URL](https://github.com/recette-lemon/invidious-copy-url) | Adds context menu options on Invidious to copy shortened YouTube URL at current time or not (Requires using developer mode in Chrome or a developer version of Firefox). | |
-| [View on Invidious](https://omar.yt/722e5c15832840fe1ae8830b7c590254b9e0a45c/invidious-bookmarklet.html) | View page on Invidious (bookmarklet). | |
-| [Inviduration](https://addons.mozilla.org/addon/inviduration) | Firefox extension that shows total duration of playlists on Invidious. | [Source](https://github.com/rsapkf/inviduration) / [Firefox](https://addons.mozilla.org/addon/inviduration) |
-| [Redirector](https://github.com/einaregilsson/Redirector) | Extension for Firefox and Chromium that can manually be configured to process Invidious Redirects. For details, see the [setup page](./redirector.md) to use it with Invidious. |
+| [Inviduration](https://github.com/rsapkf/inviduration) | Firefox extension that shows total duration of playlists on Invidious. | [Source](https://github.com/rsapkf/inviduration) / [Firefox](https://addons.mozilla.org/addon/inviduration) |
 
 ### Userscripts for Invidious.
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -10,24 +10,24 @@ Lists of third-party projects that use or support Invidious.
 | [Yattee](https://github.com/yattee/yattee) | Alternative YouTube frontend for iPhone, iPad, Mac and Apple TV. | [App Store](https://apps.apple.com/app/yattee/id1595136629) |
 | [CloudTube](https://sr.ht/~cadence/tube/) | A JavaScript-rich alternate online YouTube player. | |
 | [HoloPlay](https://github.com/stephane-r/holoplay-pwa)| Progressive Web App for music connecting on Invidious API's with search, playlists and favorites. | |
-| [PlasmaTube](https://invent.kde.org/multimedia/plasmatube/) | YouTube client for Linux. | [KDE Applications](https://apps.kde.org/plasmatube/) |
-| [GTK+ Pipe Viewer](https://github.com/trizen/pipe-viewer) | YouTube client for Linux. | |
 | [WatchTube](https://github.com/WatchTubeTeam/) | Powerful YouTube client for Apple Watch. | [App Store](https://apps.apple.com/app/watchtube/id1599884909) |
-| [Playlet](https://github.com/iBicha/playlet) | A Roku TV YouTube app that uses Invidious as a backend. | [Roku Store](https://channelstore.roku.com/en-ca/details/840aec36f51bfe6d96cf6db9055a372a/playlet) |
 | [TubiTui](https://codeberg.org/777/TubiTui) | A lightweight, libre, TUI-based YouTube client. For desktop. | |
 | [Ytfzf](https://github.com/pystardust/ytfzf) | A posix script to find and watch youtube videos from the terminal. (Without API). | |
+| [Playlet](https://github.com/iBicha/playlet) | A Roku TV YouTube app that uses Invidious as a backend. | [Roku Store](https://channelstore.roku.com/en-ca/details/840aec36f51bfe6d96cf6db9055a372a/playlet) |
+| [GTK+ Pipe Viewer](https://github.com/trizen/pipe-viewer) | YouTube client for Linux. | |
+| [PlasmaTube](https://invent.kde.org/multimedia/plasmatube/) | YouTube client for Linux. | [KDE Applications](https://apps.kde.org/plasmatube/) |
 
 ### Browser Extensions
 
 | Name | Description | Links |
 |---|---|---|
-| [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) | Redirects YouTube to Invidious, Twitter to Nitter, and Instagram to Bibliogram. | [Source](https://github.com/SimonBrazell/privacy-redirect) / [Firefox](https://addons.mozilla.org/addon/privacy-redirect) / [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb) |
-| [Alter](https://github.com/w3bdev1/alter) | Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. | [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter) |
-| [Redirector](https://github.com/einaregilsson/Redirector) | Extension for Firefox and Chromium that can manually be configured to process Invidious Redirects. For details, see the [setup page](./redirector.md) to use it with Invidious. | [Source](https://github.com/einaregilsson/Redirector) / [Firefox](https://addons.mozilla.org/addon/redirector) / [Chrome](https://chrome.google.com/webstore/detail/redirector/ocgpenflpmgnfapjedencafcfakcekcd) |
 | [View on Invidious](https://omar.yt/722e5c15832840fe1ae8830b7c590254b9e0a45c/invidious-bookmarklet.html) | View page on Invidious (bookmarklet). | |
-| [SponsorBlock](https://github.com/ajayyy/SponsorBlock) | A crowd-sourced extension to skip sponsorships. Support invidious instances if enabled in the options. | [Source](https://github.com/ajayyy/SponsorBlock) / [Firefox](https://addons.mozilla.org/addon/sponsorblock) / [Chrome](https://chrome.google.com/webstore/detail/mnjggcdmjocbbbhaepdhchncahnbgone) |
+| [Redirector](https://github.com/einaregilsson/Redirector) | Extension for Firefox and Chromium that can manually be configured to process Invidious Redirects. For details, see the [setup page](./redirector.md) to use it with Invidious. | [Source](https://github.com/einaregilsson/Redirector) / [Firefox](https://addons.mozilla.org/addon/redirector) / [Chrome](https://chrome.google.com/webstore/detail/redirector/ocgpenflpmgnfapjedencafcfakcekcd) |
 | [Invidious Copy URL](https://github.com/recette-lemon/invidious-copy-url) | Adds context menu options on Invidious to copy shortened YouTube URL at current time or not (Requires using developer mode in Chrome or a developer version of Firefox). | |
+| [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) | Redirects YouTube to Invidious, Twitter to Nitter, and Instagram to Bibliogram. | [Source](https://github.com/SimonBrazell/privacy-redirect) / [Firefox](https://addons.mozilla.org/addon/privacy-redirect) / [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb) |
+| [SponsorBlock](https://github.com/ajayyy/SponsorBlock) | A crowd-sourced extension to skip sponsorships. Support invidious instances if enabled in the options. | [Source](https://github.com/ajayyy/SponsorBlock) / [Firefox](https://addons.mozilla.org/addon/sponsorblock) / [Chrome](https://chrome.google.com/webstore/detail/mnjggcdmjocbbbhaepdhchncahnbgone) |
 | [Inviduration](https://github.com/rsapkf/inviduration) | Firefox extension that shows total duration of playlists on Invidious. | [Source](https://github.com/rsapkf/inviduration) / [Firefox](https://addons.mozilla.org/addon/inviduration) |
+| [Alter](https://github.com/w3bdev1/alter) | Firefox extension that redirects YouTube, Twitter and Reddit to Invidious, Nitter and Teddit respectively. | [Source](https://github.com/w3bdev1/alter) / [Firefox](https://addons.mozilla.org/addon/alter) |
 
 ### Userscripts for Invidious.
 
@@ -45,9 +45,9 @@ Lists of third-party projects that use or support Invidious.
 
 | Name | Description | Links |
 |---|---|---|
-| [UntrackMe](https://f-droid.org/en/packages/app.fedilab.nitterizeme) | Android app to rewrite YouTube links to Invidious. Can optionally play videos in the app as well. | |
 | [iPhone Redirector Shortcut](https://www.icloud.com/shortcuts/6bbf26d989cf4d07a5fe1626efbc0950) | Automatically open YouTube videos in Invidious (iPhone shortcut). | |
 | [FreshRSS Extension](https://github.com/tmiland/freshrss-invidious) | A FreshRSS extension to directly embed videos from Invidious channel feeds. | |
+| [UntrackMe](https://f-droid.org/en/packages/app.fedilab.nitterizeme) | Android app to rewrite YouTube links to Invidious. Can optionally play videos in the app as well. | |
 | [Kodi add-on](https://github.com/lekma/plugin.video.invidious) | Watch YouTube videos in the Kodi media center, using the Invidious API. Privacy-friendly alternative to the YouTube API add-on. | |
 
 ### Utilities


### PR DESCRIPTION
No apps will be added or reduced. The explanations are also intact.

----
Changes:

**Applications**

* PlasmaTube is developing quickly, so go up. Multi-language is also available.
* Playlet for Roku is for a relatively minor OS, so go down
* Yattee and WatchTube have also in the App Store.

**Browser Extensions**

* Unifies URL usage patterns for Alter, Inviduration
* Add add-on link for Redirector
* Subgrouping tools for redirects
