### PR TITLE
API: Remove references to `fields` and `pretty`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,14 +4,6 @@
 
 All endpoints that return a JSON body support `&hl=LANGUAGE` for translating fields into the desired language. A list of languages are provided in [List of URL parameters](./url-parameters.md).
 
-### Pretty
-
-All endpoints that return a JSON body support `&pretty=1` for printing the response as formatted JSON.
-
-### Fields
-
-All endpoints that return a JSON body support the [fields API](https://developers.google.com/youtube/v3/getting-started#fields) for specifying desired fields to reduce bandwidth consumption. This can be used by adding `&fields=FIELDS` with the desired fields, for example [`/api/v1/videos/aqz-KE-bpKQ?fields=videoId,title,description&pretty=1`](https://invidio.us/api/v1/videos/aqz-KE-bpKQ?fields=videoId,title,description&pretty=1).
-
 ##### GET `/api/v1/stats`
 
 > Schema:

--- a/docs/api/authenticated-endpoints.md
+++ b/docs/api/authenticated-endpoints.md
@@ -114,7 +114,7 @@ Provides an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/Event
 
 Important to note is that an event will also be sent when a channel _changes_ an already uploaded video, for example changing description or title.
 
-Each event is a JSON object with the same schema as `/api/v1/videos`. The `fields` API can be used, which will be applied to each object.
+Each event is a JSON object with the same schema as `/api/v1/videos`.
 
 A `debug` topic can also provided which will return a (psuedo-)randomly selected video every minute.
 


### PR DESCRIPTION
These parameters were removed in this PR: https://github.com/iv-org/invidious/pull/4276/