### PR TITLE
Remove youtube.owacon.moe since instance is banned from YT everyday

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -56,8 +56,6 @@
 
 * [inv.n8pjl.ca](https://inv.n8pjl.ca) 🇨🇦  
 
-* [youtube.owacon.moe](https://youtube.owacon.moe) 🇯🇵  
-
 * [invidious.jing.rocks](https://invidious.jing.rocks) 🇯🇵  
 
 ### Tor Onion Services:


### PR DESCRIPTION
removed "* [youtube.owacon.moe](https://youtube.owacon.moe) 🇯🇵  " since the website says that it has been banned from YT everyday. I don't know when but i checked today and that's what the page says.