### PR TITLE
Use trending api for health checks instead of comments

### DIFF
--- a/docs/community-installation-guide.md
+++ b/docs/community-installation-guide.md
@@ -53,7 +53,7 @@ podman create --rm \
 --pod videos \
 --name invidious \
 --label "io.containers.autoupdate=registry" \
---health-cmd="wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1" \
+--health-cmd="wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1" \
 --health-interval=30s \
 --health-timeout=5s \
 --health-retries=2 \

--- a/docs/improve-public-instance.md
+++ b/docs/improve-public-instance.md
@@ -134,7 +134,7 @@ We assume that you have not changed the port `3000` from the default installatio
                     statistics_enabled: true
                     hmac_key: "CHANGE_ME!!"
             healthcheck:
-                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
                 interval: 30s
                 timeout: 5s
                 retries: 2
@@ -166,7 +166,7 @@ We assume that you have not changed the port `3000` from the default installatio
                     statistics_enabled: true
                     hmac_key: "CHANGE_ME!!"
             healthcheck:
-                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
                 interval: 30s
                 timeout: 5s
                 retries: 2
@@ -295,7 +295,7 @@ But if you do not have NGINX as **your main reverse proxy** you can either try t
                     # statistics_enabled: false
                     hmac_key: "CHANGE_ME!!"
             healthcheck:
-                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
                 interval: 30s
                 timeout: 5s
                 retries: 2
@@ -324,7 +324,7 @@ But if you do not have NGINX as **your main reverse proxy** you can either try t
                     # statistics_enabled: false
                     hmac_key: "CHANGE_ME!!"
             healthcheck:
-                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+                test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
                 interval: 30s
                 timeout: 5s
                 retries: 2

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,7 +59,7 @@ services:
         # statistics_enabled: false
         hmac_key: "CHANGE_ME!!"
     healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s
       timeout: 5s
       retries: 2


### PR DESCRIPTION
Using the Trending API by default for health checks is a nice workaround for heath checks failing due to the new comment format. I also imagine that going to the Trending API every 30 seconds might appear to be more normal than getting comments from a specific video every 30 seconds (even if that video is very popular).

_This is a docs PR for: https://github.com/iv-org/invidious/pull/4561_
