### PR TITLE
Don't use http3-proxy for storyboards.

### DIFF
--- a/docs/improve-public-instance.md
+++ b/docs/improve-public-instance.md
@@ -237,7 +237,7 @@ But if you do not have NGINX as **your main reverse proxy** you can either try t
    Replace `33:33` with uid:gid if you have something different.
 4. Add these lines for the "server" section of Invidious in your NGINX configuration, just after the block `location /`:
    ```
-   location ~ (^/videoplayback|^/vi/|^/ggpht/|^/sb/) {
+   location ~ (^/videoplayback|^/vi/|^/ggpht/) {
         proxy_buffering on;
         proxy_buffers 1024 16k;
         proxy_set_header X-Forwarded-For "";


### PR DESCRIPTION
Using http3-proxy returns 403 for video storyboards. After removing `^/sb/` storyboards were able to load.
I did this on my instance and storyboards were able to load without problems and they are now handled by Invidious. Feel free to test it before merging it.