### PR TITLE
Clarify public instance rules and definition of analytics

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_instance.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instance.yaml
@@ -44,7 +44,7 @@ body:
         required: true
       - label: "If dash, proxy + download is enabled (default settings), the instance has unlimited traffic/bandwidth or close to unlimited (100TB minimum)"
         required: true
-      - label: "Instance is not running any kind of analytics"
+      - label: "Instance is not running any kind of analytics, including external scripts of any kind"
         required: true
       - label: "If using Cloudflare or any other DDoS protection service, settings are configured to allow uptime monitoring. Cloudflare users can consult [this](https://updown.io/doc/known-issues-when-monitoring-a-cloudflare-protected-website) guide"
         required: true

--- a/.github/ISSUE_TEMPLATE/new_instance.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instance.yaml
@@ -60,6 +60,14 @@ body:
       - label: "Ensure a proper uptime of my instance (around 90%)"
         required: true
 
+  - type: checkboxes
+    attributes:
+      label: Rules for public instances
+      description: By submitting this proposal, you agree to follow the [rules for public instances](https://docs.invidious.io/instances). 
+      options:
+        - label: I agree to follow the rules for public instances
+          required: true
+
   - type: input
     id: country
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_instance.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instance.yaml
@@ -63,7 +63,7 @@ body:
   - type: checkboxes
     attributes:
       label: Rules for public instances
-      description: By submitting this proposal, you agree to follow the [rules for public instances](https://docs.invidious.io/instances). 
+      description: By submitting this proposal, you agree to follow the [rules for public instances](https://docs.invidious.io/instances/#rules-for-public-instances). 
       options:
         - label: I agree to follow the rules for public instances
           required: true

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -100,7 +100,7 @@
 6. Instances MUST be served via HTTPS (or/and onion).
 7. Instances using any DDoS Protection / MITM MUST be marked as such (e.g. Cloudflare, DDoS-Guard).
 8. Instances using any type of anti-bot protection MUST be marked as such.
-9. Instances MUST NOT use any type of analytics.
+9. Instances MUST NOT use any type of analytics, including external scripts of any kind.
 10. Any system whose goal is to modify the content served to the user (i.e web server HTML rewrite) is considered the same as modifying the source code.
 11. Instances running a modified source code:
     - MUST respect the [GNU AGPL](https://en.wikipedia.org/wiki/GNU_Affero_General_Public_License) by publishing their source code and stating their changes **before** they are added to the list

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -90,7 +90,7 @@
 
 * [zzlsbhhfvwg3oh36tcvx4r7n6jrw7zibvyvfxqlodcwn3mfrvzuq.b32.i2p](http://zzlsbhhfvwg3oh36tcvx4r7n6jrw7zibvyvfxqlodcwn3mfrvzuq.b32.i2p) 🇨🇱 (Eepsite of inv.nadeko.net)
 
-## Rules to have your instance in this list:
+## Rules for public instances
 
 1. Instances MUST have been up for at least a month before it can be added to this list.
 2. Instances MUST have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and is removed from the list.

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -90,7 +90,7 @@
 
 * [zzlsbhhfvwg3oh36tcvx4r7n6jrw7zibvyvfxqlodcwn3mfrvzuq.b32.i2p](http://zzlsbhhfvwg3oh36tcvx4r7n6jrw7zibvyvfxqlodcwn3mfrvzuq.b32.i2p) 🇨🇱 (Eepsite of inv.nadeko.net)
 
-## Rules for public instances
+## Rules to have your instance in this list:
 
 1. Instances MUST have been up for at least a month before it can be added to this list.
 2. Instances MUST have been updated in the last month. An instance that hasn't been updated in the last month is considered unmaintained and is removed from the list.


### PR DESCRIPTION
This PR aims to address some issues in the process for proposing a new instance.

1. The existence of the rules for public instances outlined at https://docs.invidious.io/instances/ is unclear. Maintainers are also not explicitly asked to agree to follow these rules.

2. **All external scripts**, not just some, are considered analytics. Ambiguity here may have caused some instances being unnecessarily delisted (see https://github.com/iv-org/documentation/issues/502 and https://github.com/iv-org/documentation/issues/534 for examples).