### PR TITLE
update invidious.protokolla.fi flag (de -> fi)

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -28,7 +28,7 @@
 
 * [inv.tux.pizza](https://inv.tux.pizza) 🇺🇸 
 
-* [invidious.protokolla.fi](https://invidious.protokolla.fi) 🇩🇪 
+* [invidious.protokolla.fi](https://invidious.protokolla.fi) 🇫🇮 
 
 * [iv.nboeck.de](https://iv.nboeck.de) 🇩🇪
 


### PR DESCRIPTION
invidious.protokolla.fi has been moved from a German host (Netcup) back to Finland (Hetzner). 

Btw, does this update also the https://api.invidious.io instance list or only the documentation?