### PR TITLE
 Remove all instances currently broken by the YouTube change (or for a different reason)

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -8,10 +8,6 @@
 
 ## List of public Invidious Instances (sorted from oldest to newest):
 
-* [yewtu.be](https://yewtu.be) 🇩🇪 - Source code/changes: https://github.com/yewtudotbe/invidious-custom
-
-* [vid.puffyan.us](https://vid.puffyan.us) 🇺🇸 
-
 * [yt.artemislena.eu](https://yt.artemislena.eu) 🇩🇪
 
 * [invidious.flokinet.to](https://invidious.flokinet.to) 🇷🇴
@@ -20,17 +16,11 @@
 
 * [iv.melmac.space](https://iv.melmac.space) 🇩🇪
 
-* [iv.ggtyler.dev](https://iv.ggtyler.dev) 🇺🇸
-
-* [invidious.lunar.icu](https://invidious.lunar.icu) 🇩🇪 (uses Cloudflare) 
-
 * [inv.nadeko.net](https://inv.nadeko.net) 🇨🇱 
 
 * [inv.tux.pizza](https://inv.tux.pizza) 🇺🇸 
 
 * [invidious.protokolla.fi](https://invidious.protokolla.fi) 🇫🇮 
-
-* [iv.nboeck.de](https://iv.nboeck.de) 🇩🇪
 
 * [invidious.private.coffee](https://invidious.private.coffee) 🇦🇹
 
@@ -42,15 +32,9 @@
 
 * [invidious.perennialte.ch](https://invidious.perennialte.ch) 🇦🇺 (uses Cloudflare)
 
-* [yt.cdaut.de](https://yt.cdaut.de) 🇩🇪
-
 * [invidious.drgns.space](https://invidious.drgns.space) 🇺🇸
 
 * [inv.us.projectsegfau.lt](https://inv.us.projectsegfau.lt) 🇺🇸
-
-* [invidious.einfachzocken.eu](https://invidious.einfachzocken.eu) 🇩🇪 
-
-* [invidious.nerdvpn.de](https://invidious.nerdvpn.de) 🇺🇦 
 
 * [invidious.jing.rocks](https://invidious.jing.rocks) 🇯🇵  
 
@@ -66,7 +50,6 @@
 
 * [invidious.darkness.services](https://invidious.darkness.services) 🇺🇸
 
-* [invidious.yourdevice.ch](https://invidious.yourdevice.ch) 🇩🇪
 
 ### Tor Onion Services:
 

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -12,8 +12,6 @@
 
 * [invidious.flokinet.to](https://invidious.flokinet.to) 🇷🇴
 
-* [invidious.privacydev.net](https://invidious.privacydev.net) 🇫🇷 
-
 * [iv.melmac.space](https://iv.melmac.space) 🇩🇪
 
 * [inv.nadeko.net](https://inv.nadeko.net) 🇨🇱 
@@ -47,8 +45,6 @@
 * [inv.in.projectsegfau.lt](https://inv.in.projectsegfau.lt) 🇮🇳
 
 * [invidious.incogniweb.net](https://invidious.incogniweb.net) 🇺🇸
-
-* [invidious.darkness.services](https://invidious.darkness.services) 🇺🇸
 
 
 ### Tor Onion Services:


### PR DESCRIPTION
Remove all instances affected by https://github.com/iv-org/invidious/issues/4734

\+

https://invidious.privacydev.net/ : 504

https://invidious.darkness.services/ : videos just don't play with or without dash