### PR TITLE
Use the new HTTP2 format for NGINX

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -6,8 +6,9 @@ This is a very basic config, secured with Let's Encrypt. Any log is disabled by 
 server {
 	listen 80;
 	listen [::]:80;
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+        http2 on;
 
 	server_name invidious.domain.tld;
 


### PR DESCRIPTION
Fixed the change of how to enable https on NGinx in newer releases