### PR TITLE
Add mention about the user that created the doc

### DIFF
--- a/docs/gluetun.md
+++ b/docs/gluetun.md
@@ -1,5 +1,7 @@
 # Make Invidious requests data from YouTube through a VPN using Gluetun (in case your IP is blocked)
 
+This tutorial has been written by [TheFrenchGhosty](https://github.com/TheFrenchGhosty). He is better suited when looking for help about this tutorial.
+
 ## Create the docker network (must be done outside of the compose file):
 
 ```


### PR DESCRIPTION
Same as https://github.com/iv-org/documentation/blob/master/docs/hide-instance-behind-proxy-server.md.

If one wants help for this "official" tutorial, he has to redirect his request to the creator of the article.