### PR TITLE
Update supported Crystal versions in "installation.md"

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,7 +110,9 @@ docker-compose up
 
 Follow the instructions for your distribution here: https://crystal-lang.org/install/
 
-Note: Invidious currently supports the following Crystal versions: `1.9.2` / `1.8.2` / `1.7.X` / `1.6.X`
+**Note:** Invidious currently supports the following Crystal versions: `1.9.2` / `1.10` / `1.11` / `1.12`. \
+Versions prior to `1.9` are incompatible because we use features from the newer versions. \
+Version `1.13.x` should be compatible, however we have not tested it.
 
 #### Install the dependencies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,9 +110,9 @@ docker-compose up
 
 Follow the instructions for your distribution here: https://crystal-lang.org/install/
 
-**Note:** Invidious currently supports the following Crystal versions: `1.9.2` / `1.10` / `1.11` / `1.12`. \
-Versions prior to `1.9` are incompatible because we use features from the newer versions. \
-Version `1.13.x` should be compatible, however we have not tested it.
+**Note:** Invidious currently supports the following Crystal versions: `1.10.x` / `1.11.x` / `1.12.x`. \
+Versions `1.9.x` and older are incompatible because we use features only present in the newer versions. \
+Versions `1.13.x` should be compatible, however we did not test it.
 
 #### Install the dependencies
 


### PR DESCRIPTION
Thanks to two different users that made me realise that it was out of sync with our CI test matrix (version 1.8 and before fail due to the missing `String.match!()` function in the stdlib)