### PR TITLE
Restore iv.datura.network instance

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -30,7 +30,7 @@
 
 * [iv.nboeck.de](https://iv.nboeck.de) 🇩🇪
 
-* [iv.nowhere.moe](https://iv.nowhere.moe) 🇫
+* [iv.nowhere.moe](https://iv.nowhere.moe) 🇫🇮
 
 ### Tor Onion Services:
 

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -30,6 +30,8 @@
 
 * [iv.nboeck.de](https://iv.nboeck.de) 🇩🇪
 
+* [iv.nowhere.moe](https://iv.nowhere.moe) 🇫
+
 ### Tor Onion Services:
 
 * [inv.nadekonw7plitnjuawu6ytjsl7jlglk2t6pyq6eftptmiv3dvqndwvyd.onion](http://inv.nadekonw7plitnjuawu6ytjsl7jlglk2t6pyq6eftptmiv3dvqndwvyd.onion) 🇨🇱 (Onion of inv.nadeko.net)


### PR DESCRIPTION
Domain was changed to https://iv.nowhere.moe/