### PR TITLE
Applications: add Koutube

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -52,6 +52,7 @@ Lists of third-party projects that use or support Invidious.
 | [FreshRSS Extension](https://github.com/tmiland/freshrss-invidious) | A FreshRSS extension to directly embed videos from Invidious channel feeds. | |
 | [UntrackMe](https://f-droid.org/en/packages/app.fedilab.nitterizeme) | Android app to rewrite YouTube links to Invidious. Can optionally play videos in the app as well. | |
 | [Kodi add-on](https://github.com/lekma/plugin.video.invidious) | Watch YouTube videos in the Kodi media center, using the Invidious API. Privacy-friendly alternative to the YouTube API add-on. | |
+| [Koutube](https://github.com/iGerman00/koutube) | Watch YouTube videos on Discord without loading the YouTube embed. Quickly replace any YouTube links using the sed syntax (s/y/k) or by swapping the <kbd>y</kbd> with a <kbd>k</kbd>. | [Source](https://github.com/iGerman00/koutube) / [Website](https://koutube.com) |
 
 ### Utilities
 


### PR DESCRIPTION
A friend suggested that I PR it here. I've had this project running for a while; it's a way to avoid loading the YouTube embed along with all the tracking and ads that come with it—primarily on Discord but also potentially on other apps. It's about as privacy-respecting as it can be while running on Cloudflare's servers, but I think it still fits the applications doc.

Let me know if you'd rather not have the links populated like that for consistency.