### PR TITLE
Add scheme to url for invidious.schenkel.eti.br

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -16,7 +16,7 @@
 
 * [invidious.f5.si](https://invidious.f5.si) 🇯🇵 - Cloudflare
 
-* [invidious.schenkel.eti.br](invidious.schenkel.eti.br) 🇧🇷 - Cloudflare
+* [invidious.schenkel.eti.br](https://invidious.schenkel.eti.br) 🇧🇷 - Cloudflare
 
 ### Tor Onion Services:
 


### PR DESCRIPTION
Invidious instances-api requires a scheme for each and every single URL or else the entire fetch logic will raise and prevent the instances list from getting updated.

This is especially noticeable on a restart where there isn't a previous list to fallback to and as such the instances api will remain an empty list.