### PR TITLE
add mising `/download` endpoint from companion on the webserver configurations

### DIFF
--- a/docs/companion-apache2.md
+++ b/docs/companion-apache2.md
@@ -18,6 +18,8 @@
         ProxyPassReverse /api/manifest/dash/id/ http://127.0.0.1:8282/
         ProxyPass /videoplayback http://127.0.0.1:8282/ nocanon
         ProxyPassReverse /videoplayback http://127.0.0.1:8282/
+        ProxyPass /download http://127.0.0.1:8282/ nocanon
+        ProxyPassReverse /download http://127.0.0.1:8282/
 
         AllowEncodedSlashes on
 
@@ -68,6 +70,8 @@ To make the VirtualHost config below actually work, you should as well:
     ProxyPassReverse /api/manifest/dash/id/ http://127.0.0.1:8282/
     ProxyPass /videoplayback http://127.0.0.1:8282/ nocanon
     ProxyPassReverse /videoplayback http://127.0.0.1:8282/
+    ProxyPass /download http://127.0.0.1:8282/ nocanon
+    ProxyPassReverse /download http://127.0.0.1:8282/
     ProxyPreserveHost On
     ProxyRequests Off
     AllowEncodedSlashes On

--- a/docs/companion-caddy.md
+++ b/docs/companion-caddy.md
@@ -10,6 +10,7 @@ https://<server_name> {
 		path /latest_version
 		path /api/manifest/dash/id/*
 		path /videoplayback*
+		path /download*
 	}
 
   reverse_proxy @companion localhost:8282

--- a/docs/companion-nginx.md
+++ b/docs/companion-nginx.md
@@ -50,6 +50,14 @@ server {
 		proxy_set_header Connection "";	# to keep alive
 	}
 
+	location /download {
+		proxy_pass http://127.0.0.1:8282;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_set_header Host $host;	# so Invidious companion knows domain
+		proxy_http_version 1.1;		# to keep alive
+		proxy_set_header Connection "";	# to keep alive
+	}
+
 	if ($https = '') { return 301 https://$host$request_uri; }	# if not connected to HTTPS, perma-redirect to HTTPS
 }
 ```


### PR DESCRIPTION
Required for download to work on invidious due to commit: https://github.com/iv-org/invidious/commit/8fd0b82c387dfd10f427c8267526223ba4dc1fce

Caddy route has been tested by someone on the Invidious matrix room:
![image](https://github.com/user-attachments/assets/a4c5d47b-784b-4f02-8441-4afd928c0227)

I tested the NGINX route and works fine. I haven't tested the Apache one but it should work.