### PR TITLE
Traefik reverse-proxy rule update: Path -> PathPrefix

### DIFF
--- a/docs/companion-traefik.md
+++ b/docs/companion-traefik.md
@@ -8,7 +8,7 @@ Do not forget to replace `<server_name>` with your domain.
 ...
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.invidious.rule=Host(`<server_name>`) && !(Path(`/companion`))"
+      - "traefik.http.routers.invidious.rule=Host(`<server_name>`) && !(PathPrefix(`/companion`))"
       - "traefik.http.routers.invidious.entrypoints=web-sec"
       - "traefik.http.routers.invidious.tls.certresolver=le"
       - "traefik.http.services.invidious.loadbalancer.server.port=3000"
@@ -19,7 +19,7 @@ Do not forget to replace `<server_name>` with your domain.
 ...
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.invidious-companion.rule=Host(`<server_name>`) && (Path(`/companion`))"
+      - "traefik.http.routers.invidious-companion.rule=Host(`<server_name>`) && (PathPrefix(`/companion`))"
       - "traefik.http.routers.invidious-companion.entrypoints=web-sec"
       - "traefik.http.routers.invidious-companion.tls.certresolver=le"
       - "traefik.http.services.invidious-companion.loadbalancer.server.port=8282"


### PR DESCRIPTION
Following https://github.com/iv-org/documentation/issues/665

https://github.com/iv-org/invidious-companion/wiki/How-to-communicate-with-Invidious-companion-with-any-client-(HTTP-API) says `/companion` is only the beginning of the API paths, not the full path