### PR TITLE
Fix companion caddy configuration

### DIFF
--- a/docs/companion-caddy.md
+++ b/docs/companion-caddy.md
@@ -6,7 +6,7 @@ Any log is disabled by default. Do not forget to replace `server_name` with your
 ```
 https://<server_name> {
 
-  reverse_proxy /companion localhost:8282
+  reverse_proxy /companion/* localhost:8282
   reverse_proxy localhost:3000
 
   log {


### PR DESCRIPTION
The url matcher should include a wildcard.

Cf https://caddyserver.com/docs/caddyfile/matchers#syntax.

Successfully fixed my production configuration, allowing me to download the videos.