### PR TITLE
Update podman quadlet docs to include companion

### DIFF
--- a/docs/community-installation-guide.md
+++ b/docs/community-installation-guide.md
@@ -145,7 +145,7 @@ AutoUpdate=registry
 Network=invidious.network
 HostName=invidious
 
-Volume=./config.yml:/invidious/config/config.yml
+Volume=./config.yml:/invidious/config/config.yml:Z
 ```
 
 ```ini
@@ -168,7 +168,7 @@ AutoUpdate=registry
 Network=invidious.network
 HostName=invidious-db
 
-Volume=invidious-db:/var/lib/postgresql/data
+Volume=invidious-db:/var/lib/postgresql/data:Z
 
 Environment=POSTGRES_DB=invidious
 Environment=POSTGRES_USER=kemal
@@ -199,7 +199,7 @@ AutoUpdate=registry
 Network=invidious.network
 HostName=invidious-companion
 
-Volume=invidious-companion-cache:/var/tmp/youtubei.js:rw
+Volume=invidious-companion-cache:/var/tmp/youtubei.js:rw,Z
 
 # WARNING: The container will fail to start without this env var
 # NOTE: The podman secret is preferred, but you may set the env var directly like this


### PR DESCRIPTION
The prior documentation appears to predate the introduction of the companion container. This commit adapts the instructions to include the new companion and some improved formatting.

Tested and running on my own system as part of [my rootless quadlet appstore project](https://git.mcgee.red/redbeardymcgee/podbox).

NOTE: I think the database should be able to initialize itself with the `check_tables: true` setting in `config.yml` but I did not confirm this yet. This is noted in the new instructions.