### PR TITLE
Adding a community guide for running Invidious on Proxmox with VMs or LXCs

### DIFF
--- a/docs/community-installation-guide.md
+++ b/docs/community-installation-guide.md
@@ -301,7 +301,32 @@ Guide contributor(s): [@SimplyProgrammer](https://github.com/SimplyProgrammer)
 This method provides a simple and straightforward guide with scripts to setup Invidious inside a Proxmox Linux VM or LXC container.
 It utilizes podman to create Invidious containers, Caddy 2 for self-signed https reverse proxy and Linux service for automatic startup.
 
-Available at https://github.com/SimplyProgrammer/Invidious-podman-LXC-VM
+### Prerequirements
+Debian 12+ VM or an unprivileged Debian 12+ LXC container with:
+* Name "invidious" (or something similar)
+* 4GB+ of RAM
+* 2+ x86_64 cores, 4 is ideal (ARM is also possible but `compose.yml` has to be modified accordingly).
+* 20+GB of storage
+* Static IP or static DHCP lease on your router.
+
+### Networking
+Further, you will need a DNS domain, paid or local one to point to this IP of your LXC/VM with Invidious. 
+It would be great if your router would allow/do this by default, and automatically assign something like `invidious.lan` or even better, `invidious.home.arpa` to your LXC/VM. For example, [OpenWrt](https://forum.openwrt.org/t/use-home-arpa-as-default-tld-for-local-network/165056/11) does this by default. For other routers, extra config might be needed.
+If you have your own domain, reversed-proxy etc., setup might differ for you...
+
+### Installation
+Run this script (with sudo privileges or as root):
+```
+mkdir -p ~/invidious-podman && cd "$_" && git clone "https://github.com/SimplyProgrammer/Invidious-podman-LXC-VM.git" . && chmod 755 setup-invidious.sh && ./setup-invidious.sh
+```
+When it asks for the Invidious git repo, for 90% of you just press enter (unless you have your own forked one).
+
+The most important part, when it asks for the DNS domain, specify aforementioned `invidious.lan`, `invidious.home.arpa` or whatever you have. But make sure the domain is reachable and working in advance (`nslookup` etc.).
+
+If everything was done properly, now you should have a working LXC/VM with Invidious service and should be able to open it at `https://<your-invidious-domain>/`.\
+It should automatically start with your VM/LXC, no extra work needed.
+
+More info and the whole solution is available for review at https://github.com/SimplyProgrammer/Invidious-podman-LXC-VM.
 
 ## MacOS
 


### PR DESCRIPTION
I have recently tried to self-host Invidious with the popular virtualization platform Proxmox, which uses LXC containers or VMs.

However, I found no existing solutions that would be satisfactory and Invidious docs also have no mention of Proxmox or LXC containers.
So I have created this guide with setup scripts https://github.com/SimplyProgrammer/Invidious-podman-LXC-VM
It was tested with Proxmox 9+ and Debian 13 LXC container, it seems to work fine.

Please review it when needed and consider adding it as part of comunity docs.
I believe it could help quite a few people.