### PR TITLE
Remove version line as it is deprecated.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,9 +46,7 @@ Make sure to run the newer Docker Compose V2: https://docs.docker.com/compose/in
 3.  Edit the docker-compose.yml with this content:
 
     ```docker
-    version: "3"
     services:
-
       invidious:
         image: quay.io/invidious/invidious:latest
         # image: quay.io/invidious/invidious:latest-arm64 # ARM64/AArch64 devices


### PR DESCRIPTION
This removes the version line from the production docker compose example, as the version strings are deprecated, per this warning: ``the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion``