### PR TITLE
Add X-Forwarded-Host header for NGINX reverse proxy

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -21,7 +21,9 @@ server {
 	location / {
 		proxy_pass http://127.0.0.1:3000;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header Host $host;	# so Invidious knows domain
+        # Needed for alternative domains to work, check Invidious `config.example.yml`
+        # file to get more details on how it works.
+        proxy_set_header X-Forwarded-Host $host;
 		proxy_http_version 1.1;		# to keep alive
 		proxy_set_header Connection "";	# to keep alive
 	}

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -20,7 +20,6 @@ server {
 
 	location / {
 		proxy_pass http://127.0.0.1:3000;
-		proxy_set_header X-Forwarded-For $remote_addr;
         # Needed for alternative domains to work, check Invidious `config.example.yml`
         # file to get more details on how it works.
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Related to https://github.com/iv-org/invidious/pull/5647

Adds the `X-Forwarded-Host` header to the NGINX Reverse Proxy configuration and removes `proxy_set_header Host` since the `Host` header is not used anywhere in Invidious code (`X-Forwarded-For` can be removed too since is not used in Invidious too).