### PR TITLE
change docker image tag from latest to master in installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ Make sure to run the newer Docker Compose V2: https://docs.docker.com/compose/in
     ```docker
     services:
       invidious:
-        image: quay.io/invidious/invidious:latest
+        image: quay.io/invidious/invidious:master
         restart: unless-stopped
         # Remove "127.0.0.1:" if used from an external IP
         ports:


### PR DESCRIPTION
Just a small change. The latest tag does not work properly with the YouTube API (returns error 400). Changing to the master tag works, as expected.

If this is the wrong way to go about this, feel free to close the PR.