### PR TITLE
chore: update api/v1/comments API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -221,13 +221,7 @@ Returns annotation XML from YouTube's `/annotations_invideo` endpoint. Alternati
   "comments": [
     {
       "author": String,
-      "authorThumbnails": [
-        {
-          "url": String,
-          "width": Int32,
-          "height": Int32
-        }
-      ],
+      "authorThumbnail": String,
       "authorId": String,
       "authorUrl": String,
 


### PR DESCRIPTION
Replaces the `authorThumbnails` key with `authorThumbnail` as Youtube no longer returns different URLs for the comment author comments in a youtube video comment.

Related to https://github.com/iv-org/invidious/pull/5862